### PR TITLE
Sniff single channelset

### DIFF
--- a/lib/MiLight/MiLightClient.cpp
+++ b/lib/MiLight/MiLightClient.cpp
@@ -8,8 +8,8 @@ MiLightRadio* MiLightClient::getRadio(const MiLightRadioType type) {
     stack = rgbwRadio;
   } else if (type == CCT) {
     stack = cctRadio;
-  } else if (type == RGBW_CCT) {
-    stack = rgbwCctRadio;
+  } else if (type == RGB_CCT) {
+    stack = rgbCctRadio;
   }
   
   if (stack != NULL) {
@@ -267,8 +267,8 @@ MiLightRadioType MiLightClient::getRadioType(const String& typeName) {
     return RGBW;
   } else if (typeName.equalsIgnoreCase("cct")) {
     return CCT;
-  } else if (typeName.equalsIgnoreCase("rgbw_cct")) {
-    return RGBW_CCT;
+  } else if (typeName.equalsIgnoreCase("rgb_cct")) {
+    return RGB_CCT;
   } else {
     return UNKNOWN;
   }
@@ -280,8 +280,8 @@ const MiLightRadioConfig& MiLightClient::getRadioConfig(const String& typeName) 
       return MilightRgbwConfig;
     case CCT:
       return MilightCctConfig;
-    case RGBW_CCT:
-      return MilightRgbwCctConfig;
+    case RGB_CCT:
+      return MilightRgbCctConfig;
     default:
       Serial.print("Unknown radio type: ");
       Serial.println(typeName);

--- a/lib/MiLight/MiLightClient.cpp
+++ b/lib/MiLight/MiLightClient.cpp
@@ -267,6 +267,8 @@ MiLightRadioType MiLightClient::getRadioType(const String& typeName) {
     return RGBW;
   } else if (typeName.equalsIgnoreCase("cct")) {
     return CCT;
+  } else if (typeName.equalsIgnoreCase("rgbw_cct")) {
+    return RGBW_CCT;
   } else {
     return UNKNOWN;
   }

--- a/lib/MiLight/MiLightClient.cpp
+++ b/lib/MiLight/MiLightClient.cpp
@@ -271,3 +271,46 @@ MiLightRadioType MiLightClient::getRadioType(const String& typeName) {
     return UNKNOWN;
   }
 }
+
+const MiLightRadioConfig& MiLightClient::getRadioConfig(const String& typeName) {
+  switch (getRadioType(typeName)) {
+    case RGBW:
+      return MilightRgbwConfig;
+    case CCT:
+      return MilightCctConfig;
+    case RGBW_CCT:
+      return MilightRgbwCctConfig;
+    default:
+      Serial.print("Unknown radio type: ");
+      Serial.println(typeName);
+      return MilightRgbwConfig;
+  }
+}
+    
+void MiLightClient::formatPacket(MiLightRadioConfig& config, uint8_t* packet, char* buffer) {
+  if (config.type == RGBW || config.type == CCT) {
+    String format = String("Request type  : %02X\n") 
+      + "Device ID     : %02X%02X\n"
+      + "b1            : %02X\n"
+      + "b2            : %02X\n"
+      + "b3            : %02X\n"
+      + "Sequence Num. : %02X";
+      
+    sprintf(
+      buffer,
+      format.c_str(),
+      packet[0],
+      packet[1], packet[2],
+      packet[3],
+      packet[4],
+      packet[5],
+      packet[6]
+    );
+  } else {
+    for (int i = 0; i < config.packetLength; i++) {
+      sprintf(buffer, "%02X ", packet[i]);
+      buffer += 3;
+    }
+    sprintf(buffer, "\n\n");
+  }
+}

--- a/lib/MiLight/MiLightClient.h
+++ b/lib/MiLight/MiLightClient.h
@@ -47,19 +47,19 @@ class MiLightClient {
     {
       rgbwRadio = new MiLightRadioStack(rf, MilightRgbwConfig);
       cctRadio = new MiLightRadioStack(rf, MilightCctConfig);
-      rgbwCctRadio = new MiLightRadioStack(rf, MilightRgbwCctConfig);
+      rgbCctRadio = new MiLightRadioStack(rf, MilightRgbCctConfig);
     }
     
     ~MiLightClient() {
       delete rgbwRadio;
       delete cctRadio;
-      delete rgbwCctRadio;
+      delete rgbCctRadio;
     }
     
     void begin() {
       rgbwRadio->getRadio()->begin();
       cctRadio->getRadio()->begin();
-      rgbwCctRadio->getRadio()->begin();
+      rgbCctRadio->getRadio()->begin();
     }
     
     void setResendCount(const unsigned int resendCount);
@@ -116,7 +116,7 @@ class MiLightClient {
     RF24 rf;
     MiLightRadioStack* rgbwRadio;
     MiLightRadioStack* cctRadio;
-    MiLightRadioStack* rgbwCctRadio;
+    MiLightRadioStack* rgbCctRadio;
     MiLightRadioType currentRadio;
     
     uint8_t sequenceNum;

--- a/lib/MiLight/MiLightClient.h
+++ b/lib/MiLight/MiLightClient.h
@@ -108,6 +108,9 @@ class MiLightClient {
     
     static uint8_t getCctStatusButton(uint8_t groupId, MiLightStatus status);
     static MiLightRadioType getRadioType(const String& typeName);
+    static const MiLightRadioConfig& getRadioConfig(const String& typeName);
+    
+    void formatPacket(MiLightRadioConfig& config, uint8_t* packet, char* buffer);
     
   private:
     RF24 rf;

--- a/lib/MiLight/MiLightRadio.cpp
+++ b/lib/MiLight/MiLightRadio.cpp
@@ -62,6 +62,8 @@ int MiLightRadio::configure() {
 
 bool MiLightRadio::available()
 {
+  configure();
+  
   if (_waiting) {
 #ifdef DEBUG_PRINTF
   printf("_waiting\n");
@@ -70,13 +72,22 @@ bool MiLightRadio::available()
   }
   
   if (_pl1167.receive(config.channels[0]) > 0) {
+#ifdef DEBUG_PRINTF
+  printf("0");
+#endif
     size_t packet_length = sizeof(_packet);
     if (_pl1167.readFIFO(_packet, packet_length) < 0) {
       return false;
     }
+#ifdef DEBUG_PRINTF
+  printf("1");
+#endif
     if (packet_length == 0 || packet_length != _packet[0] + 1U) {
       return false;
     }
+#ifdef DEBUG_PRINTF
+  printf("2");
+#endif
     uint32_t packet_id = PACKET_ID(_packet);
     if (packet_id == _prev_packet_id) {
       _dupes_received++;

--- a/lib/MiLight/MiLightRadio.cpp
+++ b/lib/MiLight/MiLightRadio.cpp
@@ -52,7 +52,8 @@ int MiLightRadio::configure() {
     return retval;
   }
 
-  retval = _pl1167.setMaxPacketLength(8);
+  // +1 to be able to buffer the length 
+  retval = _pl1167.setMaxPacketLength(config.packetLength + 1);
   if (retval < 0) {
     return retval;
   }
@@ -60,10 +61,7 @@ int MiLightRadio::configure() {
   return 0;
 }
 
-bool MiLightRadio::available()
-{
-  configure();
-  
+bool MiLightRadio::available() {
   if (_waiting) {
 #ifdef DEBUG_PRINTF
   printf("_waiting\n");
@@ -73,14 +71,14 @@ bool MiLightRadio::available()
   
   if (_pl1167.receive(config.channels[0]) > 0) {
 #ifdef DEBUG_PRINTF
-  printf("0");
+  printf("MiLightRadio - received packet!\n");
 #endif
     size_t packet_length = sizeof(_packet);
     if (_pl1167.readFIFO(_packet, packet_length) < 0) {
       return false;
     }
 #ifdef DEBUG_PRINTF
-  printf("1");
+  printf("MiLightRadio - Checking packet length (expecting %d, is %d)\n", _packet[0] + 1U, packet_length);
 #endif
     if (packet_length == 0 || packet_length != _packet[0] + 1U) {
       return false;

--- a/lib/MiLight/MiLightRadio.h
+++ b/lib/MiLight/MiLightRadio.h
@@ -32,12 +32,14 @@ class MiLightRadio {
     int write(uint8_t frame[], size_t frame_length);
     int resend();
     int configure();
+    
   private:
     AbstractPL1167 &_pl1167;
     const MiLightRadioConfig& config;
     uint32_t _prev_packet_id;
 
-    uint8_t _packet[8], _out_packet[8];
+    uint8_t _packet[10];
+    uint8_t _out_packet[10];
     bool _waiting;
     int _dupes_received;
 };

--- a/lib/MiLight/MiLightRadio.h
+++ b/lib/MiLight/MiLightRadio.h
@@ -16,6 +16,8 @@
 #include "AbstractPL1167.h"
 #include <MiLightRadioConfig.h>
 
+#define DEBUG_PRINTF
+
 #ifndef MILIGHTRADIO_H_
 #define MILIGHTRADIO_H_
 

--- a/lib/MiLight/MiLightRadioConfig.h
+++ b/lib/MiLight/MiLightRadioConfig.h
@@ -46,7 +46,7 @@ static MiLightRadioConfig MilightCctConfig(
 
 const uint8_t RGBWCCT_CHANNELS[] = {70, 39, 8};
 static MiLightRadioConfig MilightRgbwCctConfig(
-  0x7236, 0x1809, 8, RGBWCCT_CHANNELS, 3, RGBW_CCT
+  0x7236, 0x1809, 9, RGBWCCT_CHANNELS, 3, RGBW_CCT
 );
 
 #endif

--- a/lib/MiLight/MiLightRadioConfig.h
+++ b/lib/MiLight/MiLightRadioConfig.h
@@ -7,7 +7,7 @@ enum MiLightRadioType {
   UNKNOWN = 0,
   RGBW  = 0xB8,
   CCT   = 0x5A,
-  RGBW_CCT = 0x99
+  RGB_CCT = 0x99
 };
 
 class MiLightRadioConfig {
@@ -44,9 +44,9 @@ static MiLightRadioConfig MilightCctConfig(
   0x050A, 0x55AA, 7, CCT_CHANNELS, 3, CCT
 );
 
-const uint8_t RGBWCCT_CHANNELS[] = {70, 39, 8};
-static MiLightRadioConfig MilightRgbwCctConfig(
-  0x7236, 0x1809, 9, RGBWCCT_CHANNELS, 3, RGBW_CCT
+const uint8_t RGBCCT_CHANNELS[] = {70, 39, 8};
+static MiLightRadioConfig MilightRgbCctConfig(
+  0x7236, 0x1809, 9, RGBCCT_CHANNELS, 3, RGB_CCT
 );
 
 #endif

--- a/lib/MiLight/PL1167_nRF24.h
+++ b/lib/MiLight/PL1167_nRF24.h
@@ -12,6 +12,8 @@
 #include "AbstractPL1167.h"
 #include "RF24.h"
 
+#define DEBUG_PRINTF
+
 #ifndef PL1167_NRF24_H_
 #define PL1167_NRF24_H_
 

--- a/lib/WebServer/MiLightHttpServer.h
+++ b/lib/WebServer/MiLightHttpServer.h
@@ -32,7 +32,7 @@ protected:
   void applySettings(Settings& settings);
   
   void handleUpdateSettings();
-  void handleListenGateway();
+  void handleListenGateway(const UrlTokenBindings* urlBindings);
   void handleUpdateGroup(const UrlTokenBindings* urlBindings);
   void handleUpdateGateway(const UrlTokenBindings* urlBindings);
   

--- a/web/index.html
+++ b/web/index.html
@@ -119,7 +119,9 @@
     var sniffRequest;
     var sniffing = false;
     var getTraffic = function() {
-      sniffRequest = $.get('/gateway_traffic', function(data) {
+      var sniffType = $('#sniff-type input:checked').data('value');
+      
+      sniffRequest = $.get('/gateway_traffic/' + sniffType, function(data) {
         $('#sniffed-traffic').html(data + $('#sniffed-traffic').html());
         getTraffic();
       });
@@ -587,6 +589,20 @@
     <div class="row">
       <div class="col-sm-12">
         <button type="button" id="sniff" class="btn btn-primary">Start Sniffing</button>
+        
+        <div class="btn-group" id="sniff-type" data-toggle="buttons">
+          <label class="btn btn-secondary active">
+            <input type="radio" name="options" autocomplete="off" data-value="rgbw" checked> RGBW
+          </label>
+          <label class="btn btn-secondary">
+            <input type="radio" name="options" autocomplete="off" data-value="cct"> CCT
+          </label>
+          <label class="btn btn-secondary">
+            <input type="radio" name="options" autocomplete="off" data-value="rgbw_cct"> RGBW+CCT
+          </label>
+        </div>
+        
+        <div> &nbsp; </div>
         
         <pre id="sniffed-traffic"></pre>
       </div>


### PR DESCRIPTION
Sniff a single channel set instead of looping through them. Should make sniffing more robust, and makes it easier to handle the fact that the new protocol is of a different length.