### PR TITLE
Refactor LT8900 reads

### DIFF
--- a/lib/MiLight/LT8900MiLightRadio.cpp
+++ b/lib/MiLight/LT8900MiLightRadio.cpp
@@ -341,9 +341,14 @@ int LT8900MiLightRadio::iReadRXBuffer(uint8_t *buffer, size_t maxBuffer) {
     _currentPacketPos += 2;
   }
 
-  #ifdef DEBUG_PRINTF
-  printf_P(PSTR("Read %d/%d bytes in RX, read %d bytes into buffer\n"), _currentPacketPos, _currentPacketLen, bufferIx);
-  #endif
+#ifdef DEBUG_PRINTF
+  printf_P(
+    PSTR("Read %d/%d bytes in RX, read %d bytes into buffer\n"),
+    _currentPacketPos,
+    _currentPacketLen,
+    bufferIx
+  );
+#endif
 
   if (_currentPacketPos >= _currentPacketLen) {
     _currentPacketPos = 0;

--- a/lib/MiLight/LT8900MiLightRadio.cpp
+++ b/lib/MiLight/LT8900MiLightRadio.cpp
@@ -303,7 +303,9 @@ bool LT8900MiLightRadio::bAvailableRegister() {
 	uint16_t value = uiReadRegister(R_STATUS);
 
   if (bitRead(value, STATUS_CRC_BIT) != 0) {
+#ifdef DEBUG_PRINTF
     Serial.println(F("LT8900: CRC failed"));
+#endif
     vResumeRX();
     return false;
   }
@@ -339,7 +341,9 @@ int LT8900MiLightRadio::iReadRXBuffer(uint8_t *buffer, size_t maxBuffer) {
     _currentPacketPos += 2;
   }
 
-  printf("Read %d/%d bytes in RX, read %d bytes into buffer\n", _currentPacketPos, _currentPacketLen, bufferIx);
+  #ifdef DEBUG_PRINTF
+  printf_P(PSTR("Read %d/%d bytes in RX, read %d bytes into buffer\n"), _currentPacketPos, _currentPacketLen, bufferIx);
+  #endif
 
   if (_currentPacketPos >= _currentPacketLen) {
     _currentPacketPos = 0;

--- a/lib/MiLight/LT8900MiLightRadio.h
+++ b/lib/MiLight/LT8900MiLightRadio.h
@@ -48,7 +48,6 @@ class LT8900MiLightRadio : public MiLightRadio {
     virtual int begin();
     virtual bool available();
     virtual int read(uint8_t frame[], size_t &frame_length);
-    virtual int dupesReceived();
     virtual int write(uint8_t frame[], size_t frame_length);
     virtual int resend();
     virtual int configure();
@@ -83,6 +82,8 @@ class LT8900MiLightRadio : public MiLightRadio {
     uint8_t _out_packet[10];
     bool _waiting;
     int _dupes_received;
+    size_t _currentPacketLen;
+    size_t _currentPacketPos;
 };
 
 

--- a/lib/MiLight/MiLightRadio.h
+++ b/lib/MiLight/MiLightRadio.h
@@ -17,7 +17,6 @@ class MiLightRadio {
     virtual int begin();
     virtual bool available();
     virtual int read(uint8_t frame[], size_t &frame_length);
-    virtual int dupesReceived();
     virtual int write(uint8_t frame[], size_t frame_length);
     virtual int resend();
     virtual int configure();

--- a/lib/MiLight/NRF24MiLightRadio.cpp
+++ b/lib/MiLight/NRF24MiLightRadio.cpp
@@ -94,12 +94,6 @@ bool NRF24MiLightRadio::available() {
   return _waiting;
 }
 
-int NRF24MiLightRadio::dupesReceived()
-{
-  return _dupes_received;
-}
-
-
 int NRF24MiLightRadio::read(uint8_t frame[], size_t &frame_length)
 {
   if (!_waiting) {


### PR DESCRIPTION
This simplifies the code to handle reads from the LT8900 at the cost of not handling duplicates. The main advantage is that it's more responsive.

I could be wrong, but I don't think it's important to handle duplicate packets for this use case. Just about always the user is only going to want to know the ID of their remote.

@WoodsterDK, would you mind sanity-checking this when you get the chance?