### PR TITLE
1.4.1

### DIFF
--- a/lib/MiLight/CctPacketFormatter.cpp
+++ b/lib/MiLight/CctPacketFormatter.cpp
@@ -156,9 +156,7 @@ void CctPacketFormatter::parsePacket(const uint8_t* packet, JsonObject& result) 
   uint8_t onOffGroupId = cctCommandIdToGroup(command);
   if (onOffGroupId < 255) {
     result["state"] = cctCommandToStatus(command) == ON ? "ON" : "OFF";
-  }
-
-  if (command == CCT_BRIGHTNESS_DOWN) {
+  } else if (command == CCT_BRIGHTNESS_DOWN) {
     result["command"] = "brightness_down";
   } else if (command == CCT_BRIGHTNESS_UP) {
     result["command"] = "brightness_up";

--- a/lib/MiLight/CctPacketFormatter.cpp
+++ b/lib/MiLight/CctPacketFormatter.cpp
@@ -158,6 +158,18 @@ void CctPacketFormatter::parsePacket(const uint8_t* packet, JsonObject& result) 
     result["state"] = cctCommandToStatus(command) == ON ? "ON" : "OFF";
   }
 
+  if (command == CCT_BRIGHTNESS_DOWN) {
+    result["command"] = "brightness_down";
+  } else if (command == CCT_BRIGHTNESS_UP) {
+    result["command"] = "brightness_up";
+  } else if (command == CCT_TEMPERATURE_DOWN) {
+    result["command"] = "temperature_down";
+  } else if (command == CCT_TEMPERATURE_UP) {
+    result["command"] = "temperature_up";
+  } else {
+    result["button_id"] = command;
+  }
+
   if (! result.containsKey("state")) {
     result["state"] = "ON";
   }

--- a/lib/MiLight/RgbCctPacketFormatter.cpp
+++ b/lib/MiLight/RgbCctPacketFormatter.cpp
@@ -124,8 +124,11 @@ void RgbCctPacketFormatter::parsePacket(const uint8_t *packet, JsonObject& resul
   uint8_t arg = packetCopy[RGB_CCT_ARGUMENT_INDEX];
 
   if (command == RGB_CCT_ON) {
-    // Group is not reliably encoded in group byte. Extract from arg byte
-    if (arg < 5) {
+    if (arg == RGB_CCT_MODE_SPEED_DOWN) {
+      result["command"] = "mode_speed_down";
+    } else if (arg == RGB_CCT_MODE_SPEED_UP) {
+      result["command"] = "mode_speed_up";
+    } else if (arg < 5) { // Group is not reliably encoded in group byte. Extract from arg byte
       result["state"] = "ON";
       result["group_id"] = arg;
     } else {
@@ -158,6 +161,11 @@ void RgbCctPacketFormatter::parsePacket(const uint8_t *packet, JsonObject& resul
     result["brightness"] = Units::rescale<uint8_t, uint8_t>(level, 255, 100);
   } else if (command == RGB_CCT_SATURATION) {
     result["saturation"] = constrain(arg - RGB_CCT_SATURATION_OFFSET, 0, 100);
+  } else if (command == RGB_CCT_MODE) {
+    result["mode"] = arg;
+  } else {
+    result["button_id"] = command;
+    result["argument"] = arg;
   }
 
   if (! result.containsKey("state")) {

--- a/lib/MiLight/RgbPacketFormatter.cpp
+++ b/lib/MiLight/RgbPacketFormatter.cpp
@@ -94,6 +94,16 @@ void RgbPacketFormatter::parsePacket(const uint8_t* packet, JsonObject& result) 
     uint16_t remappedColor = Units::rescale<uint16_t, uint16_t>(packet[RGB_COLOR_INDEX], 360.0, 255.0);
     remappedColor = (remappedColor + 320) % 360;
     result["hue"] = remappedColor;
+  } else if (command == RGB_MODE_DOWN) {
+    result["command"] = "previous_mode";
+  } else if (command == RGB_MODE_UP) {
+    result["command"] = "next_mode";
+  } else if (command == RGB_SPEED_DOWN) {
+    result["command"] = "mode_speed_down";
+  } else if (command == RGB_SPEED_UP) {
+    result["command"] = "mode_speed_up";
+  } else {
+    result["button_id"] = command;
   }
 
   if (! result.containsKey("state")) {

--- a/lib/MiLight/RgbwPacketFormatter.cpp
+++ b/lib/MiLight/RgbwPacketFormatter.cpp
@@ -116,6 +116,12 @@ void RgbwPacketFormatter::parsePacket(const uint8_t* packet, JsonObject& result)
     uint16_t remappedColor = Units::rescale<uint16_t, uint16_t>(packet[RGBW_COLOR_INDEX], 360.0, 255.0);
     remappedColor = (remappedColor + 320) % 360;
     result["hue"] = remappedColor;
+  } else if (command == RGBW_SPEED_DOWN) {
+    result["command"] = "mode_speed_down";
+  } else if (command == RGBW_SPEED_UP) {
+    result["command"] = "mode_speed_up";
+  } else if (command == RGBW_DISCO_MODE) {
+    result["mode"] = packet[0] & ~RGBW;
   } else {
     result["button_id"] = command;
   }

--- a/lib/MiLight/RgbwPacketFormatter.cpp
+++ b/lib/MiLight/RgbwPacketFormatter.cpp
@@ -3,6 +3,7 @@
 #include <Units.h>
 
 #define STATUS_COMMAND(status, groupId) ( RGBW_GROUP_1_ON + ((groupId - 1)*2) + status )
+#define GROUP_FOR_STATUS_COMMAND(buttonId) ( (buttonId - 1) / 2 )
 
 void RgbwPacketFormatter::initializePacket(uint8_t* packet) {
   size_t packetPtr = 0;
@@ -101,6 +102,10 @@ void RgbwPacketFormatter::parsePacket(const uint8_t* packet, JsonObject& result)
 
   if (command >= RGBW_ALL_ON && command <= RGBW_GROUP_4_OFF) {
     result["state"] = (command % 2) ? "ON" : "OFF";
+    // Determine group ID from button ID for on/off. The remote's state is from
+    // the last packet sent, not the current one, and that can be wrong for
+    // on/off commands.
+    result["group_id"] = GROUP_FOR_STATUS_COMMAND(command);
   } else if (command == RGBW_BRIGHTNESS) {
     uint8_t brightness = 31;
     brightness -= packet[RGBW_BRIGHTNESS_GROUP_INDEX] >> 3;

--- a/lib/MiLight/RgbwPacketFormatter.cpp
+++ b/lib/MiLight/RgbwPacketFormatter.cpp
@@ -116,6 +116,8 @@ void RgbwPacketFormatter::parsePacket(const uint8_t* packet, JsonObject& result)
     uint16_t remappedColor = Units::rescale<uint16_t, uint16_t>(packet[RGBW_COLOR_INDEX], 360.0, 255.0);
     remappedColor = (remappedColor + 320) % 360;
     result["hue"] = remappedColor;
+  } else {
+    result["button_id"] = command;
   }
 
   if (! result.containsKey("state")) {

--- a/platformio.ini
+++ b/platformio.ini
@@ -18,7 +18,7 @@ lib_deps_external =
   ArduinoJson
   PubSubClient
   https://github.com/ratkins/RGBConverter
-build_flags = !python .get_version.py
+build_flags = !python .get_version.py -DMQTT_MAX_PACKET_SIZE=200
 # -D MQTT_DEBUG
 # -D MILIGHT_UDP_DEBUG
 # -D DEBUG_PRINTF


### PR DESCRIPTION
## Bug fixes

* ( #97 ) add support for mode, mode speed up/down for RGB, RGBW, and RGB+CCT bulb types.
* ( #98 ) RGBW: fix bug where group ID was ID of last group used. This was a problem for on/off commands.