### PR TITLE
Bufix checksum in CCT packet.

### DIFF
--- a/lib/MiLight/CctPacketFormatter.cpp
+++ b/lib/MiLight/CctPacketFormatter.cpp
@@ -35,6 +35,18 @@ void CctPacketFormatter::initializePacket(uint8_t* packet) {
   // Byte 9: CRC MSB
 }
 
+void CctPacketFormatter::finalizePacket(uint8_t* packet) {
+  uint8_t checksum;
+
+  // Calculate checksum over packet length .. sequenceNum
+  checksum = 7; // Packet length is not part of packet
+  for (uint8_t i = 0; i < 6; i++) {
+    checksum += currentPacket[i];
+  }
+  // Store the checksum in the sixth byte
+  currentPacket[6] = checksum;
+}
+
 void CctPacketFormatter::updateBrightness(uint8_t value) {
   valueByStepFunction(
     &PacketFormatter::increaseBrightness,
@@ -54,21 +66,11 @@ void CctPacketFormatter::updateTemperature(uint8_t value) {
 }
 
 void CctPacketFormatter::command(uint8_t command, uint8_t arg) {
-  uint8_t checksum;
-
   pushPacket();
   if (held) {
     command |= 0x80;
   }
   currentPacket[CCT_COMMAND_INDEX] = command;
-
-  // Calculate checksum over packet length .. sequenceNum
-  checksum = 7; // Packet length is not part of packet
-  for (uint8_t i = 0; i < 6; i++) {
-    checksum += currentPacket[i];
-  }
-  // Store the checksum in the sixth byte
-  currentPacket[6] = checksum;
 }
 
 void CctPacketFormatter::updateStatus(MiLightStatus status, uint8_t groupId) {

--- a/lib/MiLight/CctPacketFormatter.cpp
+++ b/lib/MiLight/CctPacketFormatter.cpp
@@ -55,7 +55,6 @@ void CctPacketFormatter::updateTemperature(uint8_t value) {
 
 void CctPacketFormatter::command(uint8_t command, uint8_t arg) {
   uint8_t checksum;
-  uint8_t i;
 
   pushPacket();
   if (held) {
@@ -65,7 +64,7 @@ void CctPacketFormatter::command(uint8_t command, uint8_t arg) {
 
   // Calculate checksum over packet length .. sequenceNum
   checksum = 7; // Packet length is not part of packet
-  for (i = 0; i < 6; i++) {
+  for (uint8_t i = 0; i < 6; i++) {
     checksum += currentPacket[i];
   }
   // Store the checksum in the sixth byte

--- a/lib/MiLight/CctPacketFormatter.cpp
+++ b/lib/MiLight/CctPacketFormatter.cpp
@@ -70,8 +70,6 @@ void CctPacketFormatter::command(uint8_t command, uint8_t arg) {
   }
   // Store the checksum in the sixth byte
   currentPacket[6] = checksum;
-
-  Serial.println(checksum, HEX);
 }
 
 void CctPacketFormatter::updateStatus(MiLightStatus status, uint8_t groupId) {

--- a/lib/MiLight/CctPacketFormatter.cpp
+++ b/lib/MiLight/CctPacketFormatter.cpp
@@ -9,13 +9,30 @@ bool CctPacketFormatter::canHandle(const uint8_t *packet, const size_t len) {
 void CctPacketFormatter::initializePacket(uint8_t* packet) {
   size_t packetPtr = 0;
 
+  // Byte 0: Packet length = 7 bytes
+
+  // Byte 1: CCT protocol
   packet[packetPtr++] = CCT_PROTOCOL_ID;
+
+  // Byte 2 and 3: Device ID
   packet[packetPtr++] = deviceId >> 8;
   packet[packetPtr++] = deviceId & 0xFF;
+
+  // Byte 4: Zone
   packet[packetPtr++] = groupId;
+
+  // Byte 5: Bulb command, filled in later
   packet[packetPtr++] = 0;
-  packet[packetPtr++] = sequenceNum;
+
+  // Byte 6: Packet sequence number 0..255
   packet[packetPtr++] = sequenceNum++;
+
+  // Byte 7: Checksum over previous bytes, including packet length = 7
+  // The checksum will be calculated when setting the command field
+  packet[packetPtr++] = 0;
+
+  // Byte 8: CRC LSB
+  // Byte 9: CRC MSB
 }
 
 void CctPacketFormatter::updateBrightness(uint8_t value) {
@@ -37,11 +54,24 @@ void CctPacketFormatter::updateTemperature(uint8_t value) {
 }
 
 void CctPacketFormatter::command(uint8_t command, uint8_t arg) {
+  uint8_t checksum;
+  uint8_t i;
+
   pushPacket();
   if (held) {
     command |= 0x80;
   }
   currentPacket[CCT_COMMAND_INDEX] = command;
+
+  // Calculate checksum over packet length .. sequenceNum
+  checksum = 7; // Packet length is not part of packet
+  for (i = 0; i < 6; i++) {
+    checksum += currentPacket[i];
+  }
+  // Store the checksum in the sixth byte
+  currentPacket[6] = checksum;
+
+  Serial.println(checksum, HEX);
 }
 
 void CctPacketFormatter::updateStatus(MiLightStatus status, uint8_t groupId) {

--- a/lib/MiLight/CctPacketFormatter.h
+++ b/lib/MiLight/CctPacketFormatter.h
@@ -45,6 +45,7 @@ public:
 
   virtual void format(uint8_t const* packet, char* buffer);
   virtual void initializePacket(uint8_t* packet);
+  virtual void finalizePacket(uint8_t* packet);
   virtual BulbId parsePacket(const uint8_t* packet, JsonObject& result, GroupStateStore* stateStore);
 
   static uint8_t getCctStatusButton(uint8_t groupId, MiLightStatus status);


### PR DESCRIPTION
Add checksum of the 7 packet bytes (including packet length = 7).
Without it, several CCT bulbs cannot be linked and do not respond
on commands. The CctPacketFormatter.cpp protocol is now identical
to the FUT006 remote CCT controller.

The CCT protocol is as follows:
```
  Byte 0: Packet length = 7 bytes
  Byte 1: CCT protocol 0x5A
  Byte 2 and 3: Device ID (16-bit)
  Byte 4: Zone 0..4
  Byte 5: Bulb command
  Byte 6: Packet sequence number 0..255
  Byte 7: Checksum over previous bytes 0..6
  Byte 8: CRC LSB over bytes 0..7
  Byte 9: CRC MSB over bytes 0..7
```

Tested with FUT011: 5W GU10 Dual White LED Spotlight, MiLight Hub web interface in CCT mode.