### PR TITLE
Default color temp rgb_cct white mode 100

### DIFF
--- a/lib/MiLight/RgbCctPacketFormatter.cpp
+++ b/lib/MiLight/RgbCctPacketFormatter.cpp
@@ -55,7 +55,7 @@ void RgbCctPacketFormatter::updateSaturation(uint8_t value) {
 }
 
 void RgbCctPacketFormatter::updateColorWhite() {
-  updateTemperature(0);
+  updateTemperature(100);
 }
 
 void RgbCctPacketFormatter::enableNightMode() {


### PR DESCRIPTION
Change the default color tempreture for the rgb_cct protecol when pressing the "white mode" button from 0 (cold white) to 100 (warm white).
In a later update this schould become the last known color temperature stored in memory from the bulb state.