### PR TITLE
Change BulbId == to exclude device type

### DIFF
--- a/lib/MiLightState/GroupState.cpp
+++ b/lib/MiLightState/GroupState.cpp
@@ -47,10 +47,15 @@ void BulbId::operator=(const BulbId &other) {
   deviceType = other.deviceType;
 }
 
+// determine if now BulbId's are the same.  This compared deviceID (the controller/remote ID) and
+// groupId (the group number on the controller, 1-4 or 1-8 depending), but ignores the deviceType
+// (type of controller/remote) as this doesn't directly affect the identity of the bulb
 bool BulbId::operator==(const BulbId &other) {
   return deviceId == other.deviceId
-    && groupId == other.groupId
-    && deviceType == other.deviceType;
+    && groupId == other.groupId;
+    // used to contain this test below for deviceType, removed as it does not identify the bulb, but instead
+    // identifies which remote is being used
+//    && deviceType == other.deviceType;
 }
 
 GroupState::GroupState() {
@@ -319,15 +324,32 @@ void GroupState::dump(Stream& stream) const {
     stream.write(reinterpret_cast<const uint8_t*>(&state.data[i]), 4);
   }
 }
+/*
+  Update group state to reflect a packet state
 
+  Called both when a packet is sent locally, and when an intercepted packet is read 
+  (see main.cpp onPacketSentHandler)
+
+  Returns true if the packet changes affects a state change
+*/
 bool GroupState::patch(const JsonObject& state) {
   bool changes = false;
 
   if (state.containsKey("state")) {
-    changes |= setState(state["state"] == "ON" ? ON : OFF);
+    bool stateChange = setState(state["state"] == "ON" ? ON : OFF);
+#ifdef DEBUG_PRINTF
+    //if (stateChange)
+    //  Serial.printf("State changed to %s", state["state"]);
+#endif
+    changes |= stateChange;
   }
   if (state.containsKey("brightness")) {
-    changes |= setBrightness(Units::rescale(state.get<uint8_t>("brightness"), 100, 255));
+    bool stateChange = setBrightness(Units::rescale(state.get<uint8_t>("brightness"), 100, 255));
+#ifdef DEBUG_PRINTF
+    //if (stateChange)
+    //  Serial.printf("Brightness changed to %d", state.get<uint8_t>("brightness"));
+#endif
+    changes |= stateChange;
   }
   if (state.containsKey("hue")) {
     changes |= setHue(state["hue"]);
@@ -362,6 +384,11 @@ bool GroupState::patch(const JsonObject& state) {
     }
   }
 
+  if (changes)
+    debugState("GroupState::patch: State changed");
+  else
+    debugState("GroupState::patch: State not changed");
+    
   return changes;
 }
 
@@ -385,6 +412,7 @@ void GroupState::applyColor(ArduinoJson::JsonObject& state, uint8_t r, uint8_t g
   color["b"] = b;
 }
 
+// gather partial state for a single field; see GroupState::applyState to gather many fields
 void GroupState::applyField(JsonObject& partialState, GroupStateField field) {
   if (isSetField(field)) {
     switch (field) {
@@ -462,6 +490,43 @@ void GroupState::applyField(JsonObject& partialState, GroupStateField field) {
   }
 }
 
+// helper function to debug the current state (in JSON) to the serial port
+void GroupState::debugState(char const *debugMessage) {
+#ifdef DEBUG_PRINTF
+  // using static to keep large buffers off the call stack
+  static char buffer[1000];
+  static StaticJsonBuffer<1000> jsonBuffer;
+
+  // define fields to show (if count changes, make sure to update count to applyState below)
+  GroupStateField fields[] { 
+      GroupStateField::BRIGHTNESS, 
+      GroupStateField::BULB_MODE,
+      GroupStateField::COLOR,
+      GroupStateField::COLOR_TEMP,
+      GroupStateField::COMPUTED_COLOR,
+      GroupStateField::EFFECT,
+      GroupStateField::HUE,
+      GroupStateField::KELVIN,
+      GroupStateField::LEVEL,
+      GroupStateField::MODE,
+      GroupStateField::SATURATION,
+      GroupStateField::STATE,
+      GroupStateField::STATUS };
+
+  // since our buffer is reused, make sure to clear it every time  
+  jsonBuffer.clear();
+  JsonObject& jsonState = jsonBuffer.createObject();
+
+  // use applyState to build JSON of all fields (from above)
+  applyState(jsonState, fields, 13);
+  // convert to string and print
+  jsonState.printTo(buffer);
+  Serial.printf("%s: %s\n", debugMessage, buffer);
+#endif
+}
+
+// build up a partial state representation based on the specified GrouipStateField array.  Used
+// to gather a subset of states (configurable in the UI) for sending to MQTT and web responses.
 void GroupState::applyState(JsonObject& partialState, GroupStateField* fields, size_t numFields) {
   for (size_t i = 0; i < numFields; i++) {
     applyField(partialState, fields[i]);

--- a/lib/MiLightState/GroupState.h
+++ b/lib/MiLightState/GroupState.h
@@ -8,6 +8,9 @@
 #ifndef _GROUP_STATE_H
 #define _GROUP_STATE_H
 
+// enable to add debugging on state
+//#define DEBUG_PRINTF
+
 struct BulbId {
   uint16_t deviceId;
   uint8_t groupId;
@@ -97,6 +100,8 @@ public:
 
   void load(Stream& stream);
   void dump(Stream& stream) const;
+
+  void debugState(char const *debugMessage);
 
   static const GroupState& defaultState(MiLightRemoteType remoteType);
 


### PR DESCRIPTION
When changing between devices (controllers/remotes), the system uses a different set of cached properties for each device type.  However, many combinations of devices can controller the same device ID/group (aka, bulbs) and changing to a different set of cached properties results in confusion if you switch between devices.  This proposed change removes device type from the "==" operator on the BulbId class, making it so that changing between device types continues to share the same properties (such as hue and brightness).