### PR TITLE
Making saturation and temperature work when on inconsistent modes

### DIFF
--- a/lib/MiLight/FUT089PacketFormatter.h
+++ b/lib/MiLight/FUT089PacketFormatter.h
@@ -11,8 +11,8 @@ enum MiLightFUT089Command {
   FUT089_COLOR = 0x02,
   FUT089_BRIGHTNESS = 0x05,
   FUT089_MODE = 0x06,
-  FUT089_KELVIN = 0x07,
-  FUT089_SATURATION = 0x07
+  FUT089_KELVIN = 0x07,     // Controls Kelvin when in White mode
+  FUT089_SATURATION = 0x07  // Controls Saturation when in Color mode
 };
 
 enum MiLightFUT089Arguments {
@@ -24,7 +24,7 @@ enum MiLightFUT089Arguments {
 class FUT089PacketFormatter : public V2PacketFormatter {
 public:
   FUT089PacketFormatter()
-    : V2PacketFormatter(0x25, 8)
+    : V2PacketFormatter(0x25, 8)    // protocol is 0x25, and there are 8 groups
   { }
 
   virtual void updateBrightness(uint8_t value);

--- a/lib/MiLight/MiLightClient.cpp
+++ b/lib/MiLight/MiLightClient.cpp
@@ -82,7 +82,7 @@ void MiLightClient::prepare(const MiLightRemoteConfig* config,
   this->currentRemote = config;
 
   if (deviceId >= 0 && groupId >= 0) {
-    currentRemote->packetFormatter->prepare(deviceId, groupId);
+    currentRemote->packetFormatter->prepare(deviceId, groupId, &stateStore);
   }
 }
 
@@ -132,10 +132,13 @@ void MiLightClient::write(uint8_t packet[]) {
   int iStart = millis();
 #endif
 
+  // send the packet out (multiple times for "reliability")
   for (int i = 0; i < this->currentResendCount; i++) {
     currentRadio->write(packet, currentRemote->packetFormatter->getPacketLength());
   }
 
+  // if we have a packetSendHandler defined (see MiLightClient::onPacketSent), call it now that
+  // the packet has been dispatched
   if (this->packetSentHandler) {
     this->packetSentHandler(packet, *currentRemote);
   }
@@ -148,105 +151,168 @@ void MiLightClient::write(uint8_t packet[]) {
 }
 
 void MiLightClient::updateColorRaw(const uint8_t color) {
+#ifdef DEBUG_CLIENT_COMMANDS
+  Serial.printf("MiLightClient::updateColorRaw: Change color to %d\n", color);
+#endif
   currentRemote->packetFormatter->updateColorRaw(color);
   flushPacket();
 }
 
 void MiLightClient::updateHue(const uint16_t hue) {
+#ifdef DEBUG_CLIENT_COMMANDS
+  Serial.printf("MiLightClient::updateHue: Change hue to %d\n", hue);
+#endif
   currentRemote->packetFormatter->updateHue(hue);
   flushPacket();
 }
 
 void MiLightClient::updateBrightness(const uint8_t brightness) {
+#ifdef DEBUG_CLIENT_COMMANDS
+  Serial.printf("MiLightClient::updateBrightness: Change brightness to %d\n", brightness);
+#endif
   currentRemote->packetFormatter->updateBrightness(brightness);
   flushPacket();
 }
 
 void MiLightClient::updateMode(uint8_t mode) {
+#ifdef DEBUG_CLIENT_COMMANDS
+  Serial.printf("MiLightClient::updateMode: Change mode to %d\n", mode);
+#endif
   currentRemote->packetFormatter->updateMode(mode);
   flushPacket();
 }
 
 void MiLightClient::nextMode() {
+#ifdef DEBUG_CLIENT_COMMANDS
+  Serial.printf("MiLightClient::nextMode: Switch to next mode\n");
+#endif
   currentRemote->packetFormatter->nextMode();
   flushPacket();
 }
 
 void MiLightClient::previousMode() {
+#ifdef DEBUG_CLIENT_COMMANDS
+  Serial.printf("MiLightClient::previousMode: Switch to previous mode\n");
+#endif
   currentRemote->packetFormatter->previousMode();
   flushPacket();
 }
 
 void MiLightClient::modeSpeedDown() {
+#ifdef DEBUG_CLIENT_COMMANDS
+  Serial.printf("MiLightClient::modeSpeedDown: Speed down\n");
+#endif
   currentRemote->packetFormatter->modeSpeedDown();
   flushPacket();
 }
 void MiLightClient::modeSpeedUp() {
+#ifdef DEBUG_CLIENT_COMMANDS
+  Serial.printf("MiLightClient::modeSpeedUp: Speed up\n");
+#endif
   currentRemote->packetFormatter->modeSpeedUp();
   flushPacket();
 }
 
 void MiLightClient::updateStatus(MiLightStatus status, uint8_t groupId) {
+#ifdef DEBUG_CLIENT_COMMANDS
+  Serial.printf("MiLightClient::updateStatus: Status %s, groupId %d\n", status == MiLightStatus::OFF ? "OFF" : "ON", groupId);
+#endif
   currentRemote->packetFormatter->updateStatus(status, groupId);
   flushPacket();
 }
 
 void MiLightClient::updateStatus(MiLightStatus status) {
+#ifdef DEBUG_CLIENT_COMMANDS
+  Serial.printf("MiLightClient::updateStatus: Status %s\n", status == MiLightStatus::OFF ? "OFF" : "ON");
+#endif
   currentRemote->packetFormatter->updateStatus(status);
   flushPacket();
 }
 
 void MiLightClient::updateSaturation(const uint8_t value) {
+#ifdef DEBUG_CLIENT_COMMANDS
+  Serial.printf("MiLightClient::updateSaturation: Saturation %d\n", value);
+#endif
   currentRemote->packetFormatter->updateSaturation(value);
   flushPacket();
 }
 
 void MiLightClient::updateColorWhite() {
+#ifdef DEBUG_CLIENT_COMMANDS
+  Serial.printf("MiLightClient::updateColorWhite: Color white\n");
+#endif
   currentRemote->packetFormatter->updateColorWhite();
   flushPacket();
 }
 
 void MiLightClient::enableNightMode() {
+#ifdef DEBUG_CLIENT_COMMANDS
+  Serial.printf("MiLightClient::enableNightMode: Night mode\n");
+#endif
   currentRemote->packetFormatter->enableNightMode();
   flushPacket();
 }
 
 void MiLightClient::pair() {
+#ifdef DEBUG_CLIENT_COMMANDS
+  Serial.printf("MiLightClient::pair: Pair\n");
+#endif
   currentRemote->packetFormatter->pair();
   flushPacket();
 }
 
 void MiLightClient::unpair() {
+#ifdef DEBUG_CLIENT_COMMANDS
+  Serial.printf("MiLightClient::unpair: Unpair\n");
+#endif
   currentRemote->packetFormatter->unpair();
   flushPacket();
 }
 
 void MiLightClient::increaseBrightness() {
+#ifdef DEBUG_CLIENT_COMMANDS
+  Serial.printf("MiLightClient::increaseBrightness: Increase brightness\n");
+#endif
   currentRemote->packetFormatter->increaseBrightness();
   flushPacket();
 }
 
 void MiLightClient::decreaseBrightness() {
+#ifdef DEBUG_CLIENT_COMMANDS
+  Serial.printf("MiLightClient::decreaseBrightness: Decrease brightness\n");
+#endif
   currentRemote->packetFormatter->decreaseBrightness();
   flushPacket();
 }
 
 void MiLightClient::increaseTemperature() {
+#ifdef DEBUG_CLIENT_COMMANDS
+  Serial.printf("MiLightClient::increaseTemperature: Increase temperature\n");
+#endif
   currentRemote->packetFormatter->increaseTemperature();
   flushPacket();
 }
 
 void MiLightClient::decreaseTemperature() {
+#ifdef DEBUG_CLIENT_COMMANDS
+  Serial.printf("MiLightClient::decreaseTemperature: Decrease temperature\n");
+#endif
   currentRemote->packetFormatter->decreaseTemperature();
   flushPacket();
 }
 
 void MiLightClient::updateTemperature(const uint8_t temperature) {
+#ifdef DEBUG_CLIENT_COMMANDS
+  Serial.printf("MiLightClient::updateTemperature: Set temperature to %d\n", temperature);
+#endif
   currentRemote->packetFormatter->updateTemperature(temperature);
   flushPacket();
 }
 
 void MiLightClient::command(uint8_t command, uint8_t arg) {
+#ifdef DEBUG_CLIENT_COMMANDS
+  Serial.printf("MiLightClient::command: Execute command %d, argument %d\n", command, arg);
+#endif
   currentRemote->packetFormatter->command(command, arg);
   flushPacket();
 }
@@ -427,6 +493,9 @@ void MiLightClient::flushPacket() {
   currentRemote->packetFormatter->reset();
 }
 
+/*
+  Register a callback for when packets are sent
+*/
 void MiLightClient::onPacketSent(PacketSentHandler handler) {
   this->packetSentHandler = handler;
 }

--- a/lib/MiLight/MiLightClient.h
+++ b/lib/MiLight/MiLightClient.h
@@ -10,6 +10,7 @@
 #define _MILIGHTCLIENT_H
 
 //#define DEBUG_PRINTF
+//#define DEBUG_CLIENT_COMMANDS     // enable to show each individual change command (like hue, brightness, etc)
 
 #define MILIGHT_DEFAULT_RESEND_COUNT 10
 //Used to determine close to white

--- a/lib/MiLight/PacketFormatter.cpp
+++ b/lib/MiLight/PacketFormatter.cpp
@@ -99,9 +99,10 @@ void PacketFormatter::valueByStepFunction(StepFunction increase, StepFunction de
   }
 }
 
-void PacketFormatter::prepare(uint16_t deviceId, uint8_t groupId) {
+void PacketFormatter::prepare(uint16_t deviceId, uint8_t groupId, GroupStateStore* stateStore) {
   this->deviceId = deviceId;
   this->groupId = groupId;
+  this->stateStore = stateStore;
   reset();
 }
 

--- a/lib/MiLight/PacketFormatter.h
+++ b/lib/MiLight/PacketFormatter.h
@@ -71,7 +71,7 @@ public:
   virtual void reset();
 
   virtual PacketStream& buildPackets();
-  virtual void prepare(uint16_t deviceId, uint8_t groupId);
+  virtual void prepare(uint16_t deviceId, uint8_t groupId, GroupStateStore* stateStore);
   virtual void format(uint8_t const* packet, char* buffer);
 
   virtual BulbId parsePacket(const uint8_t* packet, JsonObject& result, GroupStateStore* stateStore);
@@ -89,6 +89,7 @@ protected:
   size_t numPackets;
   bool held;
   PacketStream packetStream;
+  GroupStateStore* stateStore;
 
   void pushPacket();
   void valueByStepFunction(StepFunction increase, StepFunction decrease, uint8_t numSteps, uint8_t value);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,6 +94,7 @@ void onPacketSentHandler(uint8_t* packet, const MiLightRemoteConfig& config) {
   const MiLightRemoteConfig& remoteConfig =
     *MiLightRemoteConfig::fromType(bulbId.deviceType);
 
+  // update state to reflect changes from this packet
   GroupState& groupState = stateStore->get(bulbId);
   groupState.patch(result);
   stateStore->set(bulbId, groupState);
@@ -141,6 +142,7 @@ void handleListen() {
         return;
       }
 
+      // update state to reflect this packet
       onPacketSentHandler(readPacket, *remoteConfig);
     }
   }


### PR DESCRIPTION
Currently, on v2 devices,  it can be confusing when changing saturation while in White mode, or changing temperature while in Color mode.  The bulb devices themselves can not do this, and the result is that the UI updates are confusing and the REST API might not affect the change desired.  On the more modern bulbs, with RGB+CCT, you can have different temperature while looking at a color, even though the bulb doesn't support updating it.  

This PR adds a capabilities to both RgbCct and FUT089 to determine what mode the device is currently in (by looking at the state) and if the device is in an incompatible mode, it switches to the correct mode, makes the change, and switches back.  For example, if in COLOR and changing Temperature, it will briefly change to White, change the temperature, and then change it back to the original color.