### PR TITLE
Handle inconsistency on saturation/temp on v2 types

### DIFF
--- a/lib/MiLight/CctPacketFormatter.cpp
+++ b/lib/MiLight/CctPacketFormatter.cpp
@@ -180,7 +180,7 @@ MiLightStatus CctPacketFormatter::cctCommandToStatus(uint8_t command) {
   }
 }
 
-BulbId CctPacketFormatter::parsePacket(const uint8_t* packet, JsonObject& result, GroupStateStore* stateStore) {
+BulbId CctPacketFormatter::parsePacket(const uint8_t* packet, JsonObject& result) {
   uint8_t command = packet[CCT_COMMAND_INDEX] & 0x7F;
 
   BulbId bulbId(

--- a/lib/MiLight/CctPacketFormatter.h
+++ b/lib/MiLight/CctPacketFormatter.h
@@ -46,7 +46,7 @@ public:
   virtual void format(uint8_t const* packet, char* buffer);
   virtual void initializePacket(uint8_t* packet);
   virtual void finalizePacket(uint8_t* packet);
-  virtual BulbId parsePacket(const uint8_t* packet, JsonObject& result, GroupStateStore* stateStore);
+  virtual BulbId parsePacket(const uint8_t* packet, JsonObject& result);
 
   static uint8_t getCctStatusButton(uint8_t groupId, MiLightStatus status);
   static uint8_t cctCommandIdToGroup(uint8_t command);

--- a/lib/MiLight/FUT089PacketFormatter.cpp
+++ b/lib/MiLight/FUT089PacketFormatter.cpp
@@ -55,7 +55,7 @@ void FUT089PacketFormatter::updateTemperature(uint8_t value) {
   BulbMode originalBulbMode = ourState.getBulbMode();
 
   // are we already in white?  If not, change to white
-  if ((settings->enableAutomaticModeSwitching) && (originalBulbMode != BulbMode::BULB_MODE_WHITE)) {
+  if (originalBulbMode != BulbMode::BULB_MODE_WHITE) {
     updateColorWhite();
   }
 

--- a/lib/MiLight/FUT089PacketFormatter.cpp
+++ b/lib/MiLight/FUT089PacketFormatter.cpp
@@ -33,8 +33,8 @@ void FUT089PacketFormatter::updateColorRaw(uint8_t value) {
 // back to the original mode.
 void FUT089PacketFormatter::updateTemperature(uint8_t value) {
   // look up our current mode 
-  BulbId* ourBulb = new BulbId(this->deviceId, this->groupId, REMOTE_TYPE_FUT089);
-  GroupState ourState = this->stateStore->get(*ourBulb);
+  BulbId ourBulb(this->deviceId, this->groupId, REMOTE_TYPE_FUT089);
+  GroupState ourState = this->stateStore->get(ourBulb);
   BulbMode originalBulbMode = ourState.getBulbMode();
 
   // are we already in white?  If not, change to white
@@ -68,8 +68,8 @@ void FUT089PacketFormatter::updateTemperature(uint8_t value) {
 // back to the original mode.
 void FUT089PacketFormatter::updateSaturation(uint8_t value) {
   // look up our current mode 
-  BulbId* ourBulb = new BulbId(this->deviceId, this->groupId, REMOTE_TYPE_FUT089);
-  GroupState ourState = this->stateStore->get(*ourBulb);
+  BulbId ourBulb(this->deviceId, this->groupId, REMOTE_TYPE_FUT089);
+  GroupState ourState = this->stateStore->get(ourBulb);
   BulbMode originalBulbMode = ourState.getBulbMode();
 
   // are we already in white?  If not, change to white

--- a/lib/MiLight/FUT089PacketFormatter.h
+++ b/lib/MiLight/FUT089PacketFormatter.h
@@ -39,7 +39,7 @@ public:
   virtual void modeSpeedUp();
   virtual void updateMode(uint8_t mode);
 
-  virtual BulbId parsePacket(const uint8_t* packet, JsonObject& result, GroupStateStore* stateStore);
+  virtual BulbId parsePacket(const uint8_t* packet, JsonObject& result);
 };
 
 #endif

--- a/lib/MiLight/FUT089PacketFormatter.h
+++ b/lib/MiLight/FUT089PacketFormatter.h
@@ -11,8 +11,8 @@ enum MiLightFUT089Command {
   FUT089_COLOR = 0x02,
   FUT089_BRIGHTNESS = 0x05,
   FUT089_MODE = 0x06,
-  FUT089_KELVIN = 0x07,
-  FUT089_SATURATION = 0x07
+  FUT089_KELVIN = 0x07,     // Controls Kelvin when in White mode
+  FUT089_SATURATION = 0x07  // Controls Saturation when in Color mode
 };
 
 enum MiLightFUT089Arguments {
@@ -24,7 +24,7 @@ enum MiLightFUT089Arguments {
 class FUT089PacketFormatter : public V2PacketFormatter {
 public:
   FUT089PacketFormatter()
-    : V2PacketFormatter(0x25, 8)
+    : V2PacketFormatter(0x25, 8)    // protocol is 0x25, and there are 8 groups
   { }
 
   virtual void updateBrightness(uint8_t value);

--- a/lib/MiLight/MiLightClient.cpp
+++ b/lib/MiLight/MiLightClient.cpp
@@ -82,7 +82,7 @@ void MiLightClient::prepare(const MiLightRemoteConfig* config,
   this->currentRemote = config;
 
   if (deviceId >= 0 && groupId >= 0) {
-    currentRemote->packetFormatter->prepare(deviceId, groupId);
+    currentRemote->packetFormatter->prepare(deviceId, groupId, &stateStore);
   }
 }
 
@@ -132,10 +132,13 @@ void MiLightClient::write(uint8_t packet[]) {
   int iStart = millis();
 #endif
 
+  // send the packet out (multiple times for "reliability")
   for (int i = 0; i < this->currentResendCount; i++) {
     currentRadio->write(packet, currentRemote->packetFormatter->getPacketLength());
   }
 
+  // if we have a packetSendHandler defined (see MiLightClient::onPacketSent), call it now that
+  // the packet has been dispatched
   if (this->packetSentHandler) {
     this->packetSentHandler(packet, *currentRemote);
   }
@@ -148,105 +151,168 @@ void MiLightClient::write(uint8_t packet[]) {
 }
 
 void MiLightClient::updateColorRaw(const uint8_t color) {
+#ifdef DEBUG_CLIENT_COMMANDS
+  Serial.printf("MiLightClient::updateColorRaw: Change color to %d\n", color);
+#endif
   currentRemote->packetFormatter->updateColorRaw(color);
   flushPacket();
 }
 
 void MiLightClient::updateHue(const uint16_t hue) {
+#ifdef DEBUG_CLIENT_COMMANDS
+  Serial.printf("MiLightClient::updateHue: Change hue to %d\n", hue);
+#endif
   currentRemote->packetFormatter->updateHue(hue);
   flushPacket();
 }
 
 void MiLightClient::updateBrightness(const uint8_t brightness) {
+#ifdef DEBUG_CLIENT_COMMANDS
+  Serial.printf("MiLightClient::updateBrightness: Change brightness to %d\n", brightness);
+#endif
   currentRemote->packetFormatter->updateBrightness(brightness);
   flushPacket();
 }
 
 void MiLightClient::updateMode(uint8_t mode) {
+#ifdef DEBUG_CLIENT_COMMANDS
+  Serial.printf("MiLightClient::updateMode: Change mode to %d\n", mode);
+#endif
   currentRemote->packetFormatter->updateMode(mode);
   flushPacket();
 }
 
 void MiLightClient::nextMode() {
+#ifdef DEBUG_CLIENT_COMMANDS
+  Serial.printf("MiLightClient::nextMode: Switch to next mode\n");
+#endif
   currentRemote->packetFormatter->nextMode();
   flushPacket();
 }
 
 void MiLightClient::previousMode() {
+#ifdef DEBUG_CLIENT_COMMANDS
+  Serial.printf("MiLightClient::previousMode: Switch to previous mode\n");
+#endif
   currentRemote->packetFormatter->previousMode();
   flushPacket();
 }
 
 void MiLightClient::modeSpeedDown() {
+#ifdef DEBUG_CLIENT_COMMANDS
+  Serial.printf("MiLightClient::modeSpeedDown: Speed down\n");
+#endif
   currentRemote->packetFormatter->modeSpeedDown();
   flushPacket();
 }
 void MiLightClient::modeSpeedUp() {
+#ifdef DEBUG_CLIENT_COMMANDS
+  Serial.printf("MiLightClient::modeSpeedUp: Speed up\n");
+#endif
   currentRemote->packetFormatter->modeSpeedUp();
   flushPacket();
 }
 
 void MiLightClient::updateStatus(MiLightStatus status, uint8_t groupId) {
+#ifdef DEBUG_CLIENT_COMMANDS
+  Serial.printf("MiLightClient::updateStatus: Status %s, groupId %d\n", status == MiLightStatus::OFF ? "OFF" : "ON", groupId);
+#endif
   currentRemote->packetFormatter->updateStatus(status, groupId);
   flushPacket();
 }
 
 void MiLightClient::updateStatus(MiLightStatus status) {
+#ifdef DEBUG_CLIENT_COMMANDS
+  Serial.printf("MiLightClient::updateStatus: Status %s\n", status == MiLightStatus::OFF ? "OFF" : "ON");
+#endif
   currentRemote->packetFormatter->updateStatus(status);
   flushPacket();
 }
 
 void MiLightClient::updateSaturation(const uint8_t value) {
+#ifdef DEBUG_CLIENT_COMMANDS
+  Serial.printf("MiLightClient::updateSaturation: Saturation %d\n", value);
+#endif
   currentRemote->packetFormatter->updateSaturation(value);
   flushPacket();
 }
 
 void MiLightClient::updateColorWhite() {
+#ifdef DEBUG_CLIENT_COMMANDS
+  Serial.printf("MiLightClient::updateColorWhite: Color white\n");
+#endif
   currentRemote->packetFormatter->updateColorWhite();
   flushPacket();
 }
 
 void MiLightClient::enableNightMode() {
+#ifdef DEBUG_CLIENT_COMMANDS
+  Serial.printf("MiLightClient::enableNightMode: Night mode\n");
+#endif
   currentRemote->packetFormatter->enableNightMode();
   flushPacket();
 }
 
 void MiLightClient::pair() {
+#ifdef DEBUG_CLIENT_COMMANDS
+  Serial.printf("MiLightClient::pair: Pair\n");
+#endif
   currentRemote->packetFormatter->pair();
   flushPacket();
 }
 
 void MiLightClient::unpair() {
+#ifdef DEBUG_CLIENT_COMMANDS
+  Serial.printf("MiLightClient::unpair: Unpair\n");
+#endif
   currentRemote->packetFormatter->unpair();
   flushPacket();
 }
 
 void MiLightClient::increaseBrightness() {
+#ifdef DEBUG_CLIENT_COMMANDS
+  Serial.printf("MiLightClient::increaseBrightness: Increase brightness\n");
+#endif
   currentRemote->packetFormatter->increaseBrightness();
   flushPacket();
 }
 
 void MiLightClient::decreaseBrightness() {
+#ifdef DEBUG_CLIENT_COMMANDS
+  Serial.printf("MiLightClient::decreaseBrightness: Decrease brightness\n");
+#endif
   currentRemote->packetFormatter->decreaseBrightness();
   flushPacket();
 }
 
 void MiLightClient::increaseTemperature() {
+#ifdef DEBUG_CLIENT_COMMANDS
+  Serial.printf("MiLightClient::increaseTemperature: Increase temperature\n");
+#endif
   currentRemote->packetFormatter->increaseTemperature();
   flushPacket();
 }
 
 void MiLightClient::decreaseTemperature() {
+#ifdef DEBUG_CLIENT_COMMANDS
+  Serial.printf("MiLightClient::decreaseTemperature: Decrease temperature\n");
+#endif
   currentRemote->packetFormatter->decreaseTemperature();
   flushPacket();
 }
 
 void MiLightClient::updateTemperature(const uint8_t temperature) {
+#ifdef DEBUG_CLIENT_COMMANDS
+  Serial.printf("MiLightClient::updateTemperature: Set temperature to %d\n", temperature);
+#endif
   currentRemote->packetFormatter->updateTemperature(temperature);
   flushPacket();
 }
 
 void MiLightClient::command(uint8_t command, uint8_t arg) {
+#ifdef DEBUG_CLIENT_COMMANDS
+  Serial.printf("MiLightClient::command: Execute command %d, argument %d\n", command, arg);
+#endif
   currentRemote->packetFormatter->command(command, arg);
   flushPacket();
 }
@@ -427,6 +493,9 @@ void MiLightClient::flushPacket() {
   currentRemote->packetFormatter->reset();
 }
 
+/*
+  Register a callback for when packets are sent
+*/
 void MiLightClient::onPacketSent(PacketSentHandler handler) {
   this->packetSentHandler = handler;
 }

--- a/lib/MiLight/MiLightClient.cpp
+++ b/lib/MiLight/MiLightClient.cpp
@@ -120,9 +120,9 @@ void MiLightClient::write(uint8_t packet[]) {
   }
 
 #ifdef DEBUG_PRINTF
-  Serial.printf("Sending packet (%d repeats): \n", this->currentResendCount);
+  Serial.printf_P(PSTR("Sending packet (%d repeats): \n"), this->currentResendCount);
   for (int i = 0; i < currentRemote->packetFormatter->getPacketLength(); i++) {
-    Serial.printf("%02X ", packet[i]);
+    Serial.printf_P(PSTR("%02X "), packet[i]);
   }
   Serial.println();
   int iStart = millis();
@@ -148,7 +148,7 @@ void MiLightClient::write(uint8_t packet[]) {
 
 void MiLightClient::updateColorRaw(const uint8_t color) {
 #ifdef DEBUG_CLIENT_COMMANDS
-  Serial.printf("MiLightClient::updateColorRaw: Change color to %d\n", color);
+  Serial.printf_P(PSTR("MiLightClient::updateColorRaw: Change color to %d\n"), color);
 #endif
   currentRemote->packetFormatter->updateColorRaw(color);
   flushPacket();
@@ -156,7 +156,7 @@ void MiLightClient::updateColorRaw(const uint8_t color) {
 
 void MiLightClient::updateHue(const uint16_t hue) {
 #ifdef DEBUG_CLIENT_COMMANDS
-  Serial.printf("MiLightClient::updateHue: Change hue to %d\n", hue);
+  Serial.printf_P(PSTR("MiLightClient::updateHue: Change hue to %d\n"), hue);
 #endif
   currentRemote->packetFormatter->updateHue(hue);
   flushPacket();
@@ -164,7 +164,7 @@ void MiLightClient::updateHue(const uint16_t hue) {
 
 void MiLightClient::updateBrightness(const uint8_t brightness) {
 #ifdef DEBUG_CLIENT_COMMANDS
-  Serial.printf("MiLightClient::updateBrightness: Change brightness to %d\n", brightness);
+  Serial.printf_P(PSTR("MiLightClient::updateBrightness: Change brightness to %d\n"), brightness);
 #endif
   currentRemote->packetFormatter->updateBrightness(brightness);
   flushPacket();
@@ -172,7 +172,7 @@ void MiLightClient::updateBrightness(const uint8_t brightness) {
 
 void MiLightClient::updateMode(uint8_t mode) {
 #ifdef DEBUG_CLIENT_COMMANDS
-  Serial.printf("MiLightClient::updateMode: Change mode to %d\n", mode);
+  Serial.printf_P(PSTR("MiLightClient::updateMode: Change mode to %d\n"), mode);
 #endif
   currentRemote->packetFormatter->updateMode(mode);
   flushPacket();
@@ -180,7 +180,7 @@ void MiLightClient::updateMode(uint8_t mode) {
 
 void MiLightClient::nextMode() {
 #ifdef DEBUG_CLIENT_COMMANDS
-  Serial.printf("MiLightClient::nextMode: Switch to next mode\n");
+  Serial.println(F("MiLightClient::nextMode: Switch to next mode"));
 #endif
   currentRemote->packetFormatter->nextMode();
   flushPacket();
@@ -188,7 +188,7 @@ void MiLightClient::nextMode() {
 
 void MiLightClient::previousMode() {
 #ifdef DEBUG_CLIENT_COMMANDS
-  Serial.printf("MiLightClient::previousMode: Switch to previous mode\n");
+  Serial.println(F("MiLightClient::previousMode: Switch to previous mode"));
 #endif
   currentRemote->packetFormatter->previousMode();
   flushPacket();
@@ -196,14 +196,14 @@ void MiLightClient::previousMode() {
 
 void MiLightClient::modeSpeedDown() {
 #ifdef DEBUG_CLIENT_COMMANDS
-  Serial.printf("MiLightClient::modeSpeedDown: Speed down\n");
+  Serial.println(F("MiLightClient::modeSpeedDown: Speed down\n"));
 #endif
   currentRemote->packetFormatter->modeSpeedDown();
   flushPacket();
 }
 void MiLightClient::modeSpeedUp() {
 #ifdef DEBUG_CLIENT_COMMANDS
-  Serial.printf("MiLightClient::modeSpeedUp: Speed up\n");
+  Serial.println(F("MiLightClient::modeSpeedUp: Speed up"));
 #endif
   currentRemote->packetFormatter->modeSpeedUp();
   flushPacket();
@@ -211,7 +211,7 @@ void MiLightClient::modeSpeedUp() {
 
 void MiLightClient::updateStatus(MiLightStatus status, uint8_t groupId) {
 #ifdef DEBUG_CLIENT_COMMANDS
-  Serial.printf("MiLightClient::updateStatus: Status %s, groupId %d\n", status == MiLightStatus::OFF ? "OFF" : "ON", groupId);
+  Serial.printf_P(PSTR("MiLightClient::updateStatus: Status %s, groupId %d\n"), status == MiLightStatus::OFF ? "OFF" : "ON", groupId);
 #endif
   currentRemote->packetFormatter->updateStatus(status, groupId);
   flushPacket();
@@ -219,7 +219,7 @@ void MiLightClient::updateStatus(MiLightStatus status, uint8_t groupId) {
 
 void MiLightClient::updateStatus(MiLightStatus status) {
 #ifdef DEBUG_CLIENT_COMMANDS
-  Serial.printf("MiLightClient::updateStatus: Status %s\n", status == MiLightStatus::OFF ? "OFF" : "ON");
+  Serial.printf_P(PSTR("MiLightClient::updateStatus: Status %s\n"), status == MiLightStatus::OFF ? "OFF" : "ON");
 #endif
   currentRemote->packetFormatter->updateStatus(status);
   flushPacket();
@@ -227,7 +227,7 @@ void MiLightClient::updateStatus(MiLightStatus status) {
 
 void MiLightClient::updateSaturation(const uint8_t value) {
 #ifdef DEBUG_CLIENT_COMMANDS
-  Serial.printf("MiLightClient::updateSaturation: Saturation %d\n", value);
+  Serial.printf_P(PSTR("MiLightClient::updateSaturation: Saturation %d\n"), value);
 #endif
   currentRemote->packetFormatter->updateSaturation(value);
   flushPacket();
@@ -235,7 +235,7 @@ void MiLightClient::updateSaturation(const uint8_t value) {
 
 void MiLightClient::updateColorWhite() {
 #ifdef DEBUG_CLIENT_COMMANDS
-  Serial.printf("MiLightClient::updateColorWhite: Color white\n");
+  Serial.println(F("MiLightClient::updateColorWhite: Color white"));
 #endif
   currentRemote->packetFormatter->updateColorWhite();
   flushPacket();
@@ -243,7 +243,7 @@ void MiLightClient::updateColorWhite() {
 
 void MiLightClient::enableNightMode() {
 #ifdef DEBUG_CLIENT_COMMANDS
-  Serial.printf("MiLightClient::enableNightMode: Night mode\n");
+  Serial.println(F("MiLightClient::enableNightMode: Night mode"));
 #endif
   currentRemote->packetFormatter->enableNightMode();
   flushPacket();
@@ -251,7 +251,7 @@ void MiLightClient::enableNightMode() {
 
 void MiLightClient::pair() {
 #ifdef DEBUG_CLIENT_COMMANDS
-  Serial.printf("MiLightClient::pair: Pair\n");
+  Serial.println(F("MiLightClient::pair: Pair"));
 #endif
   currentRemote->packetFormatter->pair();
   flushPacket();
@@ -259,7 +259,7 @@ void MiLightClient::pair() {
 
 void MiLightClient::unpair() {
 #ifdef DEBUG_CLIENT_COMMANDS
-  Serial.printf("MiLightClient::unpair: Unpair\n");
+  Serial.println(F("MiLightClient::unpair: Unpair"));
 #endif
   currentRemote->packetFormatter->unpair();
   flushPacket();
@@ -267,7 +267,7 @@ void MiLightClient::unpair() {
 
 void MiLightClient::increaseBrightness() {
 #ifdef DEBUG_CLIENT_COMMANDS
-  Serial.printf("MiLightClient::increaseBrightness: Increase brightness\n");
+  Serial.println(F("MiLightClient::increaseBrightness: Increase brightness"));
 #endif
   currentRemote->packetFormatter->increaseBrightness();
   flushPacket();
@@ -275,7 +275,7 @@ void MiLightClient::increaseBrightness() {
 
 void MiLightClient::decreaseBrightness() {
 #ifdef DEBUG_CLIENT_COMMANDS
-  Serial.printf("MiLightClient::decreaseBrightness: Decrease brightness\n");
+  Serial.println(F("MiLightClient::decreaseBrightness: Decrease brightness"));
 #endif
   currentRemote->packetFormatter->decreaseBrightness();
   flushPacket();
@@ -283,7 +283,7 @@ void MiLightClient::decreaseBrightness() {
 
 void MiLightClient::increaseTemperature() {
 #ifdef DEBUG_CLIENT_COMMANDS
-  Serial.printf("MiLightClient::increaseTemperature: Increase temperature\n");
+  Serial.println(F("MiLightClient::increaseTemperature: Increase temperature"));
 #endif
   currentRemote->packetFormatter->increaseTemperature();
   flushPacket();
@@ -291,7 +291,7 @@ void MiLightClient::increaseTemperature() {
 
 void MiLightClient::decreaseTemperature() {
 #ifdef DEBUG_CLIENT_COMMANDS
-  Serial.printf("MiLightClient::decreaseTemperature: Decrease temperature\n");
+  Serial.println(F("MiLightClient::decreaseTemperature: Decrease temperature"));
 #endif
   currentRemote->packetFormatter->decreaseTemperature();
   flushPacket();
@@ -299,7 +299,7 @@ void MiLightClient::decreaseTemperature() {
 
 void MiLightClient::updateTemperature(const uint8_t temperature) {
 #ifdef DEBUG_CLIENT_COMMANDS
-  Serial.printf("MiLightClient::updateTemperature: Set temperature to %d\n", temperature);
+  Serial.printf_P(PSTR("MiLightClient::updateTemperature: Set temperature to %d\n"), temperature);
 #endif
   currentRemote->packetFormatter->updateTemperature(temperature);
   flushPacket();
@@ -307,7 +307,7 @@ void MiLightClient::updateTemperature(const uint8_t temperature) {
 
 void MiLightClient::command(uint8_t command, uint8_t arg) {
 #ifdef DEBUG_CLIENT_COMMANDS
-  Serial.printf("MiLightClient::command: Execute command %d, argument %d\n", command, arg);
+  Serial.printf_P(PSTR("MiLightClient::command: Execute command %d, argument %d\n"), command, arg);
 #endif
   currentRemote->packetFormatter->command(command, arg);
   flushPacket();

--- a/lib/MiLight/MiLightClient.h
+++ b/lib/MiLight/MiLightClient.h
@@ -10,6 +10,7 @@
 #define _MILIGHTCLIENT_H
 
 //#define DEBUG_PRINTF
+//#define DEBUG_CLIENT_COMMANDS     // enable to show each individual change command (like hue, brightness, etc)
 
 #define MILIGHT_DEFAULT_RESEND_COUNT 10
 //Used to determine close to white

--- a/lib/MiLight/MiLightClient.h
+++ b/lib/MiLight/MiLightClient.h
@@ -20,10 +20,8 @@ class MiLightClient {
 public:
   MiLightClient(
     MiLightRadioFactory* radioFactory,
-    GroupStateStore& stateStore,
-    size_t throttleThreshold,
-    size_t throttleSensitivity,
-    size_t packetRepeatMinimum
+    GroupStateStore* stateStore,
+    Settings* settings
   );
 
   ~MiLightClient() {
@@ -90,7 +88,8 @@ protected:
   MiLightRadio* currentRadio;
   const MiLightRemoteConfig* currentRemote;
   const size_t numRadios;
-  GroupStateStore& stateStore;
+  GroupStateStore* stateStore;
+  const Settings* settings;
 
   PacketSentHandler packetSentHandler;
   EventHandler updateBeginHandler;
@@ -100,9 +99,6 @@ protected:
   unsigned long lastSend;
   int currentResendCount;
   unsigned int baseResendCount;
-  int packetRepeatMinimum;
-  size_t throttleThreshold;
-  size_t throttleSensitivity;
 
   // This will be pre-computed, but is simply:
   //

--- a/lib/MiLight/MiLightRemoteConfig.cpp
+++ b/lib/MiLight/MiLightRemoteConfig.cpp
@@ -32,14 +32,16 @@ const MiLightRemoteConfig* MiLightRemoteConfig::fromType(const String& type) {
     return &FUT098Config;
   }
 
-  Serial.println(F("ERROR - tried to fetch remote config for type"));
+  Serial.print(F("MiLightRemoteConfig::fromType: ERROR - tried to fetch remote config for type: "));
+  Serial.println(type);
 
   return NULL;
 }
 
 const MiLightRemoteConfig* MiLightRemoteConfig::fromType(MiLightRemoteType type) {
   if (type == REMOTE_TYPE_UNKNOWN || type >= size(ALL_REMOTES)) {
-    Serial.println(F("ERROR - tried to fetch remote config for unknown type"));
+    Serial.print(F("MiLightRemoteConfig::fromType: ERROR - tried to fetch remote config for unknown type: "));
+    Serial.println(type);
     return NULL;
   }
 
@@ -61,7 +63,7 @@ const MiLightRemoteConfig* MiLightRemoteConfig::fromReceivedPacket(
 
   // This can happen under normal circumstances, so not an error condition
 #ifdef DEBUG_PRINTF
-  Serial.println(F("ERROR - tried to fetch remote config for unknown packet"));
+  Serial.println(F("MiLightRemoteConfig::fromReceivedPacket: ERROR - tried to fetch remote config for unknown packet"));
 #endif
 
   return NULL;

--- a/lib/MiLight/PacketFormatter.cpp
+++ b/lib/MiLight/PacketFormatter.cpp
@@ -64,7 +64,7 @@ void PacketFormatter::enableNightMode() { }
 void PacketFormatter::updateTemperature(uint8_t value) { }
 void PacketFormatter::updateSaturation(uint8_t value) { }
 
-BulbId PacketFormatter::parsePacket(const uint8_t *packet, JsonObject &result, GroupStateStore* stateStore) {
+BulbId PacketFormatter::parsePacket(const uint8_t *packet, JsonObject &result) {
   return DEFAULT_BULB_ID;
 }
 
@@ -99,10 +99,11 @@ void PacketFormatter::valueByStepFunction(StepFunction increase, StepFunction de
   }
 }
 
-void PacketFormatter::prepare(uint16_t deviceId, uint8_t groupId, GroupStateStore* stateStore) {
+void PacketFormatter::prepare(uint16_t deviceId, uint8_t groupId, GroupStateStore* stateStore, const Settings* settings) {
   this->deviceId = deviceId;
   this->groupId = groupId;
   this->stateStore = stateStore;
+  this->settings = settings;
   reset();
 }
 

--- a/lib/MiLight/PacketFormatter.cpp
+++ b/lib/MiLight/PacketFormatter.cpp
@@ -99,9 +99,10 @@ void PacketFormatter::valueByStepFunction(StepFunction increase, StepFunction de
   }
 }
 
-void PacketFormatter::prepare(uint16_t deviceId, uint8_t groupId) {
+void PacketFormatter::prepare(uint16_t deviceId, uint8_t groupId, GroupStateStore* stateStore) {
   this->deviceId = deviceId;
   this->groupId = groupId;
+  this->stateStore = stateStore;
   reset();
 }
 

--- a/lib/MiLight/PacketFormatter.h
+++ b/lib/MiLight/PacketFormatter.h
@@ -5,6 +5,7 @@
 #include <ArduinoJson.h>
 #include <GroupState.h>
 #include <GroupStateStore.h>
+#include <Settings.h>
 
 #ifndef _PACKET_FORMATTER_H
 #define _PACKET_FORMATTER_H
@@ -71,10 +72,10 @@ public:
   virtual void reset();
 
   virtual PacketStream& buildPackets();
-  virtual void prepare(uint16_t deviceId, uint8_t groupId, GroupStateStore* stateStore);
+  virtual void prepare(uint16_t deviceId, uint8_t groupId, GroupStateStore* stateStore, const Settings* settings);
   virtual void format(uint8_t const* packet, char* buffer);
 
-  virtual BulbId parsePacket(const uint8_t* packet, JsonObject& result, GroupStateStore* stateStore);
+  virtual BulbId parsePacket(const uint8_t* packet, JsonObject& result);
 
   static void formatV1Packet(uint8_t const* packet, char* buffer);
 
@@ -89,7 +90,8 @@ protected:
   size_t numPackets;
   bool held;
   PacketStream packetStream;
-  GroupStateStore* stateStore;
+  GroupStateStore* stateStore = NULL;
+  const Settings* settings = NULL;
 
   void pushPacket();
   void valueByStepFunction(StepFunction increase, StepFunction decrease, uint8_t numSteps, uint8_t value);

--- a/lib/MiLight/PacketFormatter.h
+++ b/lib/MiLight/PacketFormatter.h
@@ -71,7 +71,7 @@ public:
   virtual void reset();
 
   virtual PacketStream& buildPackets();
-  virtual void prepare(uint16_t deviceId, uint8_t groupId);
+  virtual void prepare(uint16_t deviceId, uint8_t groupId, GroupStateStore* stateStore);
   virtual void format(uint8_t const* packet, char* buffer);
 
   virtual BulbId parsePacket(const uint8_t* packet, JsonObject& result, GroupStateStore* stateStore);
@@ -89,6 +89,7 @@ protected:
   size_t numPackets;
   bool held;
   PacketStream packetStream;
+  GroupStateStore* stateStore;
 
   void pushPacket();
   void valueByStepFunction(StepFunction increase, StepFunction decrease, uint8_t numSteps, uint8_t value);

--- a/lib/MiLight/RgbCctPacketFormatter.cpp
+++ b/lib/MiLight/RgbCctPacketFormatter.cpp
@@ -50,8 +50,8 @@ void RgbCctPacketFormatter::updateTemperature(uint8_t value) {
   // in white mode, that makes changing temperature annoying because the current hue/mode
   // is lost.  So lookup our current bulb mode, and if needed, reset the hue/mode after
   // changing the temperature
-  BulbId* ourBulb = new BulbId(this->deviceId, this->groupId, REMOTE_TYPE_FUT089);
-  GroupState ourState = this->stateStore->get(*ourBulb);
+  BulbId ourBulb(this->deviceId, this->groupId, REMOTE_TYPE_FUT089);
+  GroupState ourState = this->stateStore->get(ourBulb);
   BulbMode originalBulbMode = ourState.getBulbMode();
 
   // now make the temperature change
@@ -79,8 +79,8 @@ void RgbCctPacketFormatter::updateTemperature(uint8_t value) {
 // mode
 void RgbCctPacketFormatter::updateSaturation(uint8_t value) {
    // look up our current mode 
-  BulbId* ourBulb = new BulbId(this->deviceId, this->groupId, REMOTE_TYPE_FUT089);
-  GroupState ourState = this->stateStore->get(*ourBulb);
+  BulbId ourBulb(this->deviceId, this->groupId, REMOTE_TYPE_FUT089);
+  GroupState ourState = this->stateStore->get(ourBulb);
   BulbMode originalBulbMode = ourState.getBulbMode();
 
   // are we already in white?  If not, change to white
@@ -112,8 +112,8 @@ void RgbCctPacketFormatter::updateSaturation(uint8_t value) {
 void RgbCctPacketFormatter::updateColorWhite() {
   // there is no direct white command, so let's look up our prior temperature and set that, which
   // causes the bulb to go white 
-  BulbId* ourBulb = new BulbId(this->deviceId, this->groupId, REMOTE_TYPE_FUT089);
-  GroupState ourState = this->stateStore->get(*ourBulb);
+  BulbId ourBulb(this->deviceId, this->groupId, REMOTE_TYPE_FUT089);
+  GroupState ourState = this->stateStore->get(ourBulb);
   uint8_t value = ((100 - ourState.getKelvin()) * 2) + RGB_CCT_KELVIN_REMOTE_END;
 
   // issue command to set kelvin to prior value, which will drive to white

--- a/lib/MiLight/RgbCctPacketFormatter.h
+++ b/lib/MiLight/RgbCctPacketFormatter.h
@@ -50,7 +50,7 @@ public:
   virtual void nextMode();
   virtual void previousMode();
 
-  virtual BulbId parsePacket(const uint8_t* packet, JsonObject& result, GroupStateStore* stateStore);
+  virtual BulbId parsePacket(const uint8_t* packet, JsonObject& result);
 
 protected:
 

--- a/lib/MiLight/RgbPacketFormatter.cpp
+++ b/lib/MiLight/RgbPacketFormatter.cpp
@@ -79,7 +79,7 @@ void RgbPacketFormatter::previousMode() {
   command(RGB_MODE_DOWN, 0);
 }
 
-BulbId RgbPacketFormatter::parsePacket(const uint8_t* packet, JsonObject& result, GroupStateStore* stateStore) {
+BulbId RgbPacketFormatter::parsePacket(const uint8_t* packet, JsonObject& result) {
   uint8_t command = packet[RGB_COMMAND_INDEX] & 0x7F;
 
   BulbId bulbId(

--- a/lib/MiLight/RgbPacketFormatter.h
+++ b/lib/MiLight/RgbPacketFormatter.h
@@ -39,7 +39,7 @@ public:
   virtual void modeSpeedUp();
   virtual void nextMode();
   virtual void previousMode();
-  virtual BulbId parsePacket(const uint8_t* packet, JsonObject& result, GroupStateStore* stateStore);
+  virtual BulbId parsePacket(const uint8_t* packet, JsonObject& result);
 
   virtual void initializePacket(uint8_t* packet);
 };

--- a/lib/MiLight/RgbwPacketFormatter.cpp
+++ b/lib/MiLight/RgbwPacketFormatter.cpp
@@ -97,7 +97,7 @@ void RgbwPacketFormatter::enableNightMode() {
   command(button | 0x10, 0);
 }
 
-BulbId RgbwPacketFormatter::parsePacket(const uint8_t* packet, JsonObject& result, GroupStateStore* stateStore) {
+BulbId RgbwPacketFormatter::parsePacket(const uint8_t* packet, JsonObject& result) {
   uint8_t command = packet[RGBW_COMMAND_INDEX] & 0x7F;
 
   BulbId bulbId(

--- a/lib/MiLight/RgbwPacketFormatter.h
+++ b/lib/MiLight/RgbwPacketFormatter.h
@@ -71,7 +71,7 @@ public:
   virtual void previousMode();
   virtual void updateMode(uint8_t mode);
   virtual void enableNightMode();
-  virtual BulbId parsePacket(const uint8_t* packet, JsonObject& result, GroupStateStore* stateStore);
+  virtual BulbId parsePacket(const uint8_t* packet, JsonObject& result);
 
   virtual void initializePacket(uint8_t* packet);
 

--- a/lib/MiLight/V2PacketFormatter.cpp
+++ b/lib/MiLight/V2PacketFormatter.cpp
@@ -83,10 +83,6 @@ uint8_t V2PacketFormatter::groupCommandArg(MiLightStatus status, uint8_t groupId
 
 // helper method to return a bulb to the prior state
 void V2PacketFormatter::switchMode(GroupState currentState, BulbMode desiredMode) {
-  // if already in the correct mode, don't bother switching
-  if (currentState.getBulbMode() == desiredMode) {
-    return;
-  }
   // revert back to the prior mode
   switch (desiredMode) {
     case BulbMode::BULB_MODE_COLOR:

--- a/lib/MiLight/V2PacketFormatter.cpp
+++ b/lib/MiLight/V2PacketFormatter.cpp
@@ -83,6 +83,10 @@ uint8_t V2PacketFormatter::groupCommandArg(MiLightStatus status, uint8_t groupId
 
 // helper method to return a bulb to the prior state
 void V2PacketFormatter::switchMode(GroupState currentState, BulbMode desiredMode) {
+  // if already in the correct mode, don't bother switching
+  if (currentState.getBulbMode() == desiredMode) {
+    return;
+  }
   // revert back to the prior mode
   switch (desiredMode) {
     case BulbMode::BULB_MODE_COLOR:
@@ -96,6 +100,9 @@ void V2PacketFormatter::switchMode(GroupState currentState, BulbMode desiredMode
       break;
     case BulbMode::BULB_MODE_WHITE:
       updateColorWhite();
+      break;
+    default:
+      Serial.printf_P(PSTR("V2PacketFormatter::switchMode: Request to switch to unknown mode %d\n"), desiredMode);
       break;
   }
   

--- a/lib/MiLight/V2PacketFormatter.cpp
+++ b/lib/MiLight/V2PacketFormatter.cpp
@@ -80,3 +80,23 @@ void V2PacketFormatter::format(uint8_t const* packet, char* buffer) {
 uint8_t V2PacketFormatter::groupCommandArg(MiLightStatus status, uint8_t groupId) {
   return GROUP_COMMAND_ARG(status, groupId, numGroups);
 }
+
+// helper method to return a bulb to the prior state
+void V2PacketFormatter::switchMode(GroupState currentState, BulbMode desiredMode) {
+  // revert back to the prior mode
+  switch (desiredMode) {
+    case BulbMode::BULB_MODE_COLOR:
+      updateHue(currentState.getHue());
+      break;
+    case BulbMode::BULB_MODE_NIGHT:
+      enableNightMode();
+      break;
+    case BulbMode::BULB_MODE_SCENE:
+      updateMode(currentState.getMode());
+      break;
+    case BulbMode::BULB_MODE_WHITE:
+      updateColorWhite();
+      break;
+  }
+  
+}

--- a/lib/MiLight/V2PacketFormatter.h
+++ b/lib/MiLight/V2PacketFormatter.h
@@ -29,6 +29,7 @@ public:
 protected:
   const uint8_t protocolId;
   const uint8_t numGroups;
+  void switchMode(GroupState currentState, BulbMode desiredMode);
 };
 
 #endif

--- a/lib/MiLightState/GroupState.cpp
+++ b/lib/MiLightState/GroupState.cpp
@@ -76,7 +76,6 @@ GroupState::GroupState() {
   state.fields._mqttDirty            = 0;
   state.fields._isSetNightMode       = 0;
   state.fields._isNightMode          = 0;
-  state.fields._isPendingSaturation  = 0;
 }
 
 bool GroupState::isSetField(GroupStateField field) const {
@@ -298,17 +297,6 @@ bool GroupState::setNightMode(bool nightMode) {
   return true;
 }
 
-bool GroupState::isPendingSaturation() const { return state.fields._isPendingSaturation; }
-bool GroupState::setPendingSaturation(bool pending) {
-  if (isPendingSaturation() == pending) {
-    return false;
-  }
-  
-  setDirty();
-  state.fields._isPendingSaturation = pending;
-  return true;
-}
-
 bool GroupState::isDirty() const { return state.fields._dirty; }
 inline bool GroupState::setDirty() {
   state.fields._dirty = 1;
@@ -323,9 +311,6 @@ void GroupState::load(Stream& stream) {
   for (size_t i = 0; i < DATA_LONGS; i++) {
     stream.readBytes(reinterpret_cast<uint8_t*>(&state.rawData[i]), 4);
   }
-  // ignore whatever value is read on pending saturation, as that field is not persisted and should
-  // always be false when starting
-  state.fields._isPendingSaturation = false;
   clearDirty();
 }
 

--- a/lib/MiLightState/GroupState.cpp
+++ b/lib/MiLightState/GroupState.cpp
@@ -76,6 +76,7 @@ GroupState::GroupState() {
   state.fields._mqttDirty            = 0;
   state.fields._isSetNightMode       = 0;
   state.fields._isNightMode          = 0;
+  state.fields._isPendingSaturation  = 0;
 }
 
 bool GroupState::isSetField(GroupStateField field) const {
@@ -297,6 +298,17 @@ bool GroupState::setNightMode(bool nightMode) {
   return true;
 }
 
+bool GroupState::isPendingSaturation() const { return state.fields._isPendingSaturation; }
+bool GroupState::setPendingSaturation(bool pending) {
+  if (isPendingSaturation() == pending) {
+    return false;
+  }
+  
+  setDirty();
+  state.fields._isPendingSaturation = pending;
+  return true;
+}
+
 bool GroupState::isDirty() const { return state.fields._dirty; }
 inline bool GroupState::setDirty() {
   state.fields._dirty = 1;
@@ -308,15 +320,18 @@ bool GroupState::isMqttDirty() const { return state.fields._mqttDirty; }
 bool GroupState::clearMqttDirty() { state.fields._mqttDirty = 0; }
 
 void GroupState::load(Stream& stream) {
-  for (size_t i = 0; i < DATA_BYTES; i++) {
-    stream.readBytes(reinterpret_cast<uint8_t*>(&state.data[i]), 4);
+  for (size_t i = 0; i < DATA_LONGS; i++) {
+    stream.readBytes(reinterpret_cast<uint8_t*>(&state.rawData[i]), 4);
   }
+  // ignore whatever value is read on pending saturation, as that field is not persisted and should
+  // always be false when starting
+  state.fields._isPendingSaturation = false;
   clearDirty();
 }
 
 void GroupState::dump(Stream& stream) const {
-  for (size_t i = 0; i < DATA_BYTES; i++) {
-    stream.write(reinterpret_cast<const uint8_t*>(&state.data[i]), 4);
+  for (size_t i = 0; i < DATA_LONGS; i++) {
+    stream.write(reinterpret_cast<const uint8_t*>(&state.rawData[i]), 4);
   }
 }
 

--- a/lib/MiLightState/GroupState.h
+++ b/lib/MiLightState/GroupState.h
@@ -83,6 +83,10 @@ public:
   bool isNightMode() const;
   bool setNightMode(bool nightMode);
 
+  // 1 bit
+  bool isPendingSaturation() const;
+  bool setPendingSaturation(bool pending);
+
   bool isDirty() const;
   inline bool setDirty();
   bool clearDirty();
@@ -101,9 +105,9 @@ public:
   static const GroupState& defaultState(MiLightRemoteType remoteType);
 
 private:
-  static const size_t DATA_BYTES = 2;
-  union Data {
-    uint32_t data[DATA_BYTES];
+  static const size_t DATA_LONGS = 3;
+  union StateData {
+    uint32_t rawData[DATA_LONGS];
     struct Fields {
       uint32_t
         _state                : 1,
@@ -115,6 +119,7 @@ private:
         _isSetState           : 1,
         _isSetHue             : 1;
       uint32_t
+        _isNightMode          : 1,
         _kelvin               : 7,
         _isSetBrightness      : 1,
         _isSetSaturation      : 1,
@@ -127,13 +132,14 @@ private:
         _isSetBrightnessMode  : 1,
         _dirty                : 1,
         _mqttDirty            : 1,
-        _isSetNightMode       : 1,
-        _isNightMode          : 1,
-                              : 2;
+        _isSetNightMode       : 1;
+      uint32_t
+        _isPendingSaturation  : 1,
+                             : 31;
     } fields;
   };
 
-  Data state;
+  StateData state;
 
   void applyColor(JsonObject& state, uint8_t r, uint8_t g, uint8_t b);
   void applyColor(JsonObject& state);

--- a/lib/MiLightState/GroupState.h
+++ b/lib/MiLightState/GroupState.h
@@ -103,7 +103,7 @@ public:
 private:
   static const size_t DATA_LONGS = 3;
   union StateData {
-    uint32_t rawData[DATA_LONGS];
+    uint32_t data[DATA_LONGS];
     struct Fields {
       uint32_t
         _state                : 1,
@@ -115,7 +115,6 @@ private:
         _isSetState           : 1,
         _isSetHue             : 1;
       uint32_t
-        _isNightMode          : 1,
         _kelvin               : 7,
         _isSetBrightness      : 1,
         _isSetSaturation      : 1,
@@ -128,7 +127,8 @@ private:
         _isSetBrightnessMode  : 1,
         _dirty                : 1,
         _mqttDirty            : 1,
-        _isSetNightMode       : 1;
+        _isSetNightMode       : 1,
+        _isNightMode          : 1;
     } fields;
   };
 

--- a/lib/MiLightState/GroupState.h
+++ b/lib/MiLightState/GroupState.h
@@ -83,10 +83,6 @@ public:
   bool isNightMode() const;
   bool setNightMode(bool nightMode);
 
-  // 1 bit
-  bool isPendingSaturation() const;
-  bool setPendingSaturation(bool pending);
-
   bool isDirty() const;
   inline bool setDirty();
   bool clearDirty();
@@ -133,9 +129,6 @@ private:
         _dirty                : 1,
         _mqttDirty            : 1,
         _isSetNightMode       : 1;
-      uint32_t
-        _isPendingSaturation  : 1,
-                             : 31;
     } fields;
   };
 

--- a/lib/MiLightState/GroupState.h
+++ b/lib/MiLightState/GroupState.h
@@ -103,7 +103,7 @@ public:
 private:
   static const size_t DATA_LONGS = 3;
   union StateData {
-    uint32_t data[DATA_LONGS];
+    uint32_t rawData[DATA_LONGS];
     struct Fields {
       uint32_t
         _state                : 1,

--- a/lib/MiLightState/GroupStateStore.cpp
+++ b/lib/MiLightState/GroupStateStore.cpp
@@ -21,6 +21,13 @@ GroupState& GroupStateStore::get(const BulbId& id) {
   return *state;
 }
 
+GroupState& GroupStateStore::get(const uint16_t deviceId, const uint8_t groupId, const MiLightRemoteType deviceType) {
+  BulbId bulbId(deviceId, groupId, deviceType);
+  return get(bulbId);
+}
+
+// save state for a bulb.  If id.groupId == 0, will iternate across all groups
+// and individually save each group (recursively)
 GroupState& GroupStateStore::set(const BulbId &id, const GroupState& state) {
   GroupState& storedState = get(id);
   storedState = state;
@@ -34,8 +41,13 @@ GroupState& GroupStateStore::set(const BulbId &id, const GroupState& state) {
       set(individualBulb, state);
     }
   }
-
+  
   return storedState;
+}
+
+GroupState& GroupStateStore::set(const uint16_t deviceId, const uint8_t groupId, const MiLightRemoteType deviceType, const GroupState& state) {
+  BulbId bulbId(deviceId, groupId, deviceType);
+  return set(bulbId, state);
 }
 
 void GroupStateStore::trackEviction() {

--- a/lib/MiLightState/GroupStateStore.h
+++ b/lib/MiLightState/GroupStateStore.h
@@ -14,12 +14,14 @@ public:
    * default state will be returned.
    */
   GroupState& get(const BulbId& id);
+  GroupState& get(const uint16_t deviceId, const uint8_t groupId, const MiLightRemoteType deviceType);
 
   /*
    * Sets the state for the given BulbId.  State will be marked as dirty and
    * flushed to persistent storage.
    */
   GroupState& set(const BulbId& id, const GroupState& state);
+  GroupState& set(const uint16_t deviceId, const uint8_t groupId, const MiLightRemoteType deviceType, const GroupState& state);
 
   /*
    * Flushes all states to persistent storage.  Returns true iff anything was

--- a/lib/Settings/Settings.cpp
+++ b/lib/Settings/Settings.cpp
@@ -103,6 +103,7 @@ void Settings::patch(JsonObject& parsedSettings) {
     this->setIfPresent(parsedSettings, "packet_repeat_throttle_threshold", packetRepeatThrottleThreshold);
     this->setIfPresent(parsedSettings, "packet_repeat_throttle_sensitivity", packetRepeatThrottleSensitivity);
     this->setIfPresent(parsedSettings, "packet_repeat_minimum", packetRepeatMinimum);
+    this->setIfPresent(parsedSettings, "enable_automatic_mode_switching", enableAutomaticModeSwitching);
 
     if (parsedSettings.containsKey("radio_interface_type")) {
       this->radioInterfaceType = Settings::typeFromString(parsedSettings["radio_interface_type"]);
@@ -179,6 +180,7 @@ void Settings::serialize(Stream& stream, const bool prettyPrint) {
   root["packet_repeat_throttle_sensitivity"] = this->packetRepeatThrottleSensitivity;
   root["packet_repeat_throttle_threshold"] = this->packetRepeatThrottleThreshold;
   root["packet_repeat_minimum"] = this->packetRepeatMinimum;
+  root["enable_automatic_mode_switching"] = this->enableAutomaticModeSwitching;
 
   if (this->deviceIds) {
     JsonArray& arr = jsonBuffer.createArray();

--- a/lib/Settings/Settings.h
+++ b/lib/Settings/Settings.h
@@ -90,7 +90,8 @@ public:
     packetRepeatThrottleSensitivity(0),
     packetRepeatMinimum(3),
     groupStateFields(NULL),
-    numGroupStateFields(0)
+    numGroupStateFields(0),
+    enableAutomaticModeSwitching(false)
   {
     if (groupStateFields == NULL) {
       numGroupStateFields = size(DEFAULT_GROUP_STATE_FIELDS);
@@ -152,6 +153,7 @@ public:
   size_t packetRepeatThrottleSensitivity;
   size_t packetRepeatThrottleThreshold;
   size_t packetRepeatMinimum;
+  bool enableAutomaticModeSwitching;
 
 protected:
   size_t _autoRestartPeriod;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -84,7 +84,7 @@ void initMilightUdpServers() {
 void onPacketSentHandler(uint8_t* packet, const MiLightRemoteConfig& config) {
   StaticJsonBuffer<200> buffer;
   JsonObject& result = buffer.createObject();
-  BulbId bulbId = config.packetFormatter->parsePacket(packet, result, stateStore);
+  BulbId bulbId = config.packetFormatter->parsePacket(packet, result);
 
   if (&bulbId == &DEFAULT_BULB_ID) {
     Serial.println(F("Skipping packet handler because packet was not decoded"));
@@ -197,10 +197,8 @@ void applySettings() {
 
   milightClient = new MiLightClient(
     radioFactory,
-    *stateStore,
-    settings.packetRepeatThrottleThreshold,
-    settings.packetRepeatThrottleSensitivity,
-    settings.packetRepeatMinimum
+    stateStore,
+    &settings
   );
   milightClient->begin();
   milightClient->onPacketSent(onPacketSentHandler);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -265,7 +265,7 @@ void setup() {
   httpServer->on("/description.xml", HTTP_GET, []() { SSDP.schema(httpServer->client()); });
   httpServer->begin();
 
-  Serial.println(F("Setup complete"));
+  Serial.printf_P(PSTR("Setup complete (version %s)\n"), QUOTE(MILIGHT_HUB_VERSION));
 }
 
 void loop() {

--- a/web/src/js/script.js
+++ b/web/src/js/script.js
@@ -10,7 +10,8 @@ var FORM_SETTINGS = [
   "mqtt_topic_pattern", "mqtt_update_topic_pattern", "mqtt_state_topic_pattern",
   "mqtt_username", "mqtt_password", "radio_interface_type", "listen_repeats",
   "state_flush_interval", "mqtt_state_rate_limit", "packet_repeat_throttle_threshold",
-  "packet_repeat_throttle_sensitivity", "packet_repeat_minimum", "group_state_fields"
+  "packet_repeat_throttle_sensitivity", "packet_repeat_minimum", "group_state_fields",
+  "enable_automatic_mode_switching"
 ];
 
 // TODO: sync this with GroupStateField.h
@@ -68,7 +69,9 @@ var FORM_SETTINGS_HELP = {
   packet_repeat_minimum : "Controls how far throttling can decrease the number " +
     "of repeated packets.  Defaults to 3.",
   group_state_fields : "Selects which fields should be included in MQTT state updates and " +
-    "REST responses for bulb state."
+    "REST responses for bulb state.",
+  enable_automatic_mode_switching: "For RGBWW bulbs (using RGB+CCT or FUT089), enables automatic switching between modes in order to affect changes to " +
+    "temperature and saturation when otherwise it would not work (true or 1 enables, false or 0 disables)."
 }
 
 var UDP_PROTOCOL_VERSIONS = [ 5, 6 ];

--- a/web/src/js/script.js
+++ b/web/src/js/script.js
@@ -71,7 +71,7 @@ var FORM_SETTINGS_HELP = {
   group_state_fields : "Selects which fields should be included in MQTT state updates and " +
     "REST responses for bulb state.",
   enable_automatic_mode_switching: "For RGBWW bulbs (using RGB+CCT or FUT089), enables automatic switching between modes in order to affect changes to " +
-    "temperature and saturation when otherwise it would not work (true or 1 enables, false or 0 disables)."
+    "temperature and saturation when otherwise it would not work."
 }
 
 var UDP_PROTOCOL_VERSIONS = [ 5, 6 ];
@@ -571,6 +571,15 @@ $(function() {
         elmt += '<option>' + stateKey + '</option>';
       });
       elmt += '</select>';
+    } else if (k == 'enable_automatic_mode_switching') {
+      elmt += '<div class="btn-group" id="enable_automatic_mode_switching" data-toggle="buttons">' +
+        '<label class="btn btn-secondary active">' +
+          '<input type="radio" id="enable_mode_switching" name="enable_automatic_mode_switching" autocomplete="off" value="true" /> Enable' +
+        '</label>'+
+        '<label class="btn btn-secondary">' +
+          '<input type="radio" id="disable_mode_switching" name="enable_automatic_mode_switching" autocomplete="off" value="false" /> Disable' +
+        '</label>' +
+      '</div>';
     } else {
       elmt += '<input type="text" class="form-control" name="' + k + '"/>';
       elmt += '</div>';


### PR DESCRIPTION
Changes to saturation and temp changes on the v2 types (rgb+cct and fut089).  Detects if current bulb mode is unable to support the feature, and briefly switches modes, applies the change, and switches back.  This is especially important for temperature, otherwise it's hard to change temperature when using color mode. 

This may be a conceptual debate about the goals of MiLightHub... as this is changing the behavior of what the hub does vs. what a remote would do.  I think in the long run, it is a nice improvement as people use MQQT and the REST API to drive bulb changes, and this implements the functionality likely desired rather than pushing the limitations of the bulbs onto the user and their automation system.