### PR TITLE
Improve state debugging

### DIFF
--- a/.build_web.py
+++ b/.build_web.py
@@ -1,5 +1,5 @@
 from shutil import copyfile
-from subprocess import check_output
+from subprocess import check_output, CalledProcessError
 import sys
 import os
 import platform
@@ -20,14 +20,25 @@ def build_web():
         os.chdir("web")
         print("Attempting to build webpage...")
         try:
-            print check_output(["npm", "install"])
-            print check_output(["node_modules/.bin/gulp"])
+            if platform.system() == "Windows":
+                print check_output(["npm.cmd", "install", "--only=dev"])
+                print check_output(["node_modules\\.bin\\gulp.cmd"])
+            else:
+                print check_output(["npm", "install"])
+                print check_output(["node_modules/.bin/gulp"])
             copyfile("build/index.html.gz.h", "../dist/index.html.gz.h")
-
-        except Exception as e:
-            print "Encountered error building webpage: ", e
+        except OSError as e:
+            print "Encountered error OSError building webpage:", e
+            if e.filename:
+                print "Filename is", e.filename
             print "WARNING: Failed to build web package. Using pre-built page."
-            pass
+        except CalledProcessError as e:
+            print e.output
+            print "Encountered error CalledProcessError building webpage:", e
+            print "WARNING: Failed to build web package. Using pre-built page."
+        except Exception as e:
+            print "Encountered error", type(e).__name__, "building webpage:", e
+            print "WARNING: Failed to build web package. Using pre-built page."
         finally:
             os.chdir("..");
 

--- a/.build_web.py
+++ b/.build_web.py
@@ -1,5 +1,5 @@
 from shutil import copyfile
-from subprocess import check_output, CalledProcessError
+from subprocess import check_output
 import sys
 import os
 import platform
@@ -20,25 +20,14 @@ def build_web():
         os.chdir("web")
         print("Attempting to build webpage...")
         try:
-            if platform.system() == "Windows":
-                print check_output(["npm.cmd", "install", "--only=dev"])
-                print check_output(["node_modules\\.bin\\gulp.cmd"])
-            else:
-                print check_output(["npm", "install"])
-                print check_output(["node_modules/.bin/gulp"])
+            print check_output(["npm", "install"])
+            print check_output(["node_modules/.bin/gulp"])
             copyfile("build/index.html.gz.h", "../dist/index.html.gz.h")
-        except OSError as e:
-            print "Encountered error OSError building webpage:", e
-            if e.filename:
-                print "Filename is", e.filename
-            print "WARNING: Failed to build web package. Using pre-built page."
-        except CalledProcessError as e:
-            print e.output
-            print "Encountered error CalledProcessError building webpage:", e
-            print "WARNING: Failed to build web package. Using pre-built page."
+
         except Exception as e:
-            print "Encountered error", type(e).__name__, "building webpage:", e
+            print "Encountered error building webpage: ", e
             print "WARNING: Failed to build web package. Using pre-built page."
+            pass
         finally:
             os.chdir("..");
 

--- a/lib/MiLightState/GroupState.cpp
+++ b/lib/MiLightState/GroupState.cpp
@@ -52,10 +52,8 @@ void BulbId::operator=(const BulbId &other) {
 // (type of controller/remote) as this doesn't directly affect the identity of the bulb
 bool BulbId::operator==(const BulbId &other) {
   return deviceId == other.deviceId
-    && groupId == other.groupId;
-    // used to contain this test below for deviceType, removed as it does not identify the bulb, but instead
-    // identifies which remote is being used
-//    && deviceType == other.deviceType;
+    && groupId == other.groupId
+    && deviceType == other.deviceType;
 }
 
 GroupState::GroupState() {

--- a/lib/MiLightState/GroupState.cpp
+++ b/lib/MiLightState/GroupState.cpp
@@ -490,10 +490,9 @@ void GroupState::applyField(JsonObject& partialState, GroupStateField field) {
 
 // helper function to debug the current state (in JSON) to the serial port
 void GroupState::debugState(char const *debugMessage) {
-#ifdef DEBUG_PRINTF
+#ifdef DEBUG_STATE
   // using static to keep large buffers off the call stack
-  static char buffer[1000];
-  static StaticJsonBuffer<1000> jsonBuffer;
+  static StaticJsonBuffer<500> jsonBuffer;
 
   // define fields to show (if count changes, make sure to update count to applyState below)
   GroupStateField fields[] { 
@@ -518,8 +517,9 @@ void GroupState::debugState(char const *debugMessage) {
   // use applyState to build JSON of all fields (from above)
   applyState(jsonState, fields, 13);
   // convert to string and print
-  jsonState.printTo(buffer);
-  Serial.printf("%s: %s\n", debugMessage, buffer);
+  Serial.printf("%s: ", debugMessage);
+  jsonState.printTo(Serial);
+  Serial.println("");
 #endif
 }
 

--- a/lib/MiLightState/GroupState.cpp
+++ b/lib/MiLightState/GroupState.cpp
@@ -47,10 +47,15 @@ void BulbId::operator=(const BulbId &other) {
   deviceType = other.deviceType;
 }
 
+// determine if now BulbId's are the same.  This compared deviceID (the controller/remote ID) and
+// groupId (the group number on the controller, 1-4 or 1-8 depending), but ignores the deviceType
+// (type of controller/remote) as this doesn't directly affect the identity of the bulb
 bool BulbId::operator==(const BulbId &other) {
   return deviceId == other.deviceId
-    && groupId == other.groupId
-    && deviceType == other.deviceType;
+    && groupId == other.groupId;
+    // used to contain this test below for deviceType, removed as it does not identify the bulb, but instead
+    // identifies which remote is being used
+//    && deviceType == other.deviceType;
 }
 
 GroupState::GroupState() {
@@ -319,15 +324,32 @@ void GroupState::dump(Stream& stream) const {
     stream.write(reinterpret_cast<const uint8_t*>(&state.data[i]), 4);
   }
 }
+/*
+  Update group state to reflect a packet state
 
+  Called both when a packet is sent locally, and when an intercepted packet is read 
+  (see main.cpp onPacketSentHandler)
+
+  Returns true if the packet changes affects a state change
+*/
 bool GroupState::patch(const JsonObject& state) {
   bool changes = false;
 
   if (state.containsKey("state")) {
-    changes |= setState(state["state"] == "ON" ? ON : OFF);
+    bool stateChange = setState(state["state"] == "ON" ? ON : OFF);
+#ifdef DEBUG_PRINTF
+    //if (stateChange)
+    //  Serial.printf("State changed to %s", state["state"]);
+#endif
+    changes |= stateChange;
   }
   if (state.containsKey("brightness")) {
-    changes |= setBrightness(Units::rescale(state.get<uint8_t>("brightness"), 100, 255));
+    bool stateChange = setBrightness(Units::rescale(state.get<uint8_t>("brightness"), 100, 255));
+#ifdef DEBUG_PRINTF
+    //if (stateChange)
+    //  Serial.printf("Brightness changed to %d", state.get<uint8_t>("brightness"));
+#endif
+    changes |= stateChange;
   }
   if (state.containsKey("hue")) {
     changes |= setHue(state["hue"]);
@@ -362,6 +384,11 @@ bool GroupState::patch(const JsonObject& state) {
     }
   }
 
+  if (changes)
+    debugState("GroupState::patch: State changed");
+  else
+    debugState("GroupState::patch: State not changed");
+    
   return changes;
 }
 
@@ -385,6 +412,7 @@ void GroupState::applyColor(ArduinoJson::JsonObject& state, uint8_t r, uint8_t g
   color["b"] = b;
 }
 
+// gather partial state for a single field; see GroupState::applyState to gather many fields
 void GroupState::applyField(JsonObject& partialState, GroupStateField field) {
   if (isSetField(field)) {
     switch (field) {
@@ -462,6 +490,43 @@ void GroupState::applyField(JsonObject& partialState, GroupStateField field) {
   }
 }
 
+// helper function to debug the current state (in JSON) to the serial port
+void GroupState::debugState(char const *debugMessage) {
+#ifdef DEBUG_PRINTF
+  // using static to keep large buffers off the call stack
+  static char buffer[1000];
+  static StaticJsonBuffer<1000> jsonBuffer;
+
+  // define fields to show (if count changes, make sure to update count to applyState below)
+  GroupStateField fields[] { 
+      GroupStateField::BRIGHTNESS, 
+      GroupStateField::BULB_MODE,
+      GroupStateField::COLOR,
+      GroupStateField::COLOR_TEMP,
+      GroupStateField::COMPUTED_COLOR,
+      GroupStateField::EFFECT,
+      GroupStateField::HUE,
+      GroupStateField::KELVIN,
+      GroupStateField::LEVEL,
+      GroupStateField::MODE,
+      GroupStateField::SATURATION,
+      GroupStateField::STATE,
+      GroupStateField::STATUS };
+
+  // since our buffer is reused, make sure to clear it every time  
+  jsonBuffer.clear();
+  JsonObject& jsonState = jsonBuffer.createObject();
+
+  // use applyState to build JSON of all fields (from above)
+  applyState(jsonState, fields, 13);
+  // convert to string and print
+  jsonState.printTo(buffer);
+  Serial.printf("%s: %s\n", debugMessage, buffer);
+#endif
+}
+
+// build up a partial state representation based on the specified GrouipStateField array.  Used
+// to gather a subset of states (configurable in the UI) for sending to MQTT and web responses.
 void GroupState::applyState(JsonObject& partialState, GroupStateField* fields, size_t numFields) {
   for (size_t i = 0; i < numFields; i++) {
     applyField(partialState, fields[i]);

--- a/lib/MiLightState/GroupState.h
+++ b/lib/MiLightState/GroupState.h
@@ -9,7 +9,7 @@
 #define _GROUP_STATE_H
 
 // enable to add debugging on state
-//#define DEBUG_PRINTF
+#define DEBUG_STATE
 
 struct BulbId {
   uint16_t deviceId;

--- a/lib/MiLightState/GroupState.h
+++ b/lib/MiLightState/GroupState.h
@@ -8,6 +8,9 @@
 #ifndef _GROUP_STATE_H
 #define _GROUP_STATE_H
 
+// enable to add debugging on state
+//#define DEBUG_PRINTF
+
 struct BulbId {
   uint16_t deviceId;
   uint8_t groupId;
@@ -97,6 +100,8 @@ public:
 
   void load(Stream& stream);
   void dump(Stream& stream) const;
+
+  void debugState(char const *debugMessage);
 
   static const GroupState& defaultState(MiLightRemoteType remoteType);
 


### PR DESCRIPTION
Currently device type is compared for state, even though only device ID and group identify a bulb.  On some bulbs (the more modern ones, with RGBWW) support multiple controllers and switching between them is confusing when state is different across device types.  For me, this is a usability issue - it is easier for me to use when state remains the same when switching between remote types.  

The larger change here is some nice debugging code to help debug state changes.
