### PR TITLE
Keep track of increment command state

### DIFF
--- a/lib/MiLight/CctPacketFormatter.cpp
+++ b/lib/MiLight/CctPacketFormatter.cpp
@@ -48,20 +48,28 @@ void CctPacketFormatter::finalizePacket(uint8_t* packet) {
 }
 
 void CctPacketFormatter::updateBrightness(uint8_t value) {
+  const GroupState& state = this->stateStore->get(deviceId, groupId, MiLightRemoteType::REMOTE_TYPE_CCT);
+  int8_t knownValue = state.isSetBrightness() ? state.getBrightness() : -1;
+
   valueByStepFunction(
     &PacketFormatter::increaseBrightness,
     &PacketFormatter::decreaseBrightness,
     CCT_INTERVALS,
-    value / CCT_INTERVALS
+    value / CCT_INTERVALS,
+    knownValue / CCT_INTERVALS
   );
 }
 
 void CctPacketFormatter::updateTemperature(uint8_t value) {
+  const GroupState& state = this->stateStore->get(deviceId, groupId, MiLightRemoteType::REMOTE_TYPE_CCT);
+  int8_t knownValue = state.isSetKelvin() ? state.getKelvin() : -1;
+
   valueByStepFunction(
     &PacketFormatter::increaseTemperature,
     &PacketFormatter::decreaseTemperature,
     CCT_INTERVALS,
-    value / CCT_INTERVALS
+    value / CCT_INTERVALS,
+    knownValue / CCT_INTERVALS
   );
 }
 

--- a/lib/MiLight/PacketFormatter.cpp
+++ b/lib/MiLight/PacketFormatter.cpp
@@ -93,6 +93,8 @@ void PacketFormatter::valueByStepFunction(StepFunction increase, StepFunction de
   StepFunction fn;
   size_t numCommands = 0;
 
+  // If current value is not known, drive down to minimum value.  Then we can assume that we
+  // know the state (it'll be 0).
   if (knownValue == -1) {
     for (size_t i = 0; i < numSteps; i++) {
       (this->*decrease)();
@@ -108,6 +110,7 @@ void PacketFormatter::valueByStepFunction(StepFunction increase, StepFunction de
     numCommands = (targetValue - knownValue);
   }
 
+  // Get to the desired value
   for (size_t i = 0; i < numCommands; i++) {
     (this->*fn)();
   }

--- a/lib/MiLight/PacketFormatter.cpp
+++ b/lib/MiLight/PacketFormatter.cpp
@@ -89,13 +89,27 @@ PacketStream& PacketFormatter::buildPackets() {
   return packetStream;
 }
 
-void PacketFormatter::valueByStepFunction(StepFunction increase, StepFunction decrease, uint8_t numSteps, uint8_t value) {
-  for (size_t i = 0; i < numSteps; i++) {
-    (this->*decrease)();
+void PacketFormatter::valueByStepFunction(StepFunction increase, StepFunction decrease, uint8_t numSteps, uint8_t targetValue, int8_t knownValue) {
+  StepFunction fn;
+  size_t numCommands = 0;
+
+  if (knownValue == -1) {
+    for (size_t i = 0; i < numSteps; i++) {
+      (this->*decrease)();
+    }
+
+    fn = increase;
+    numCommands = targetValue;
+  } else if (targetValue < knownValue) {
+    fn = decrease;
+    numCommands = (knownValue - targetValue);
+  } else if (targetValue > knownValue) {
+    fn = increase;
+    numCommands = (targetValue - knownValue);
   }
 
-  for (size_t i = 0; i < value; i++) {
-    (this->*increase)();
+  for (size_t i = 0; i < numCommands; i++) {
+    (this->*fn)();
   }
 }
 

--- a/lib/MiLight/PacketFormatter.h
+++ b/lib/MiLight/PacketFormatter.h
@@ -94,6 +94,13 @@ protected:
   const Settings* settings = NULL;
 
   void pushPacket();
+
+  // Get field into a desired state using only increment/decrement commands.  Do this by:
+  //   1. Driving it down to its minimum value
+  //   2. Applying the appropriate number of increase commands to get it to the desired
+  //      value.
+  // If the current state is already known, take that into account and apply the exact
+  // number of rpeeats for the appropriate command.
   void valueByStepFunction(StepFunction increase, StepFunction decrease, uint8_t numSteps, uint8_t targetValue, int8_t knownValue = -1);
 
   virtual void initializePacket(uint8_t* packetStart) = 0;

--- a/lib/MiLight/PacketFormatter.h
+++ b/lib/MiLight/PacketFormatter.h
@@ -94,7 +94,7 @@ protected:
   const Settings* settings = NULL;
 
   void pushPacket();
-  void valueByStepFunction(StepFunction increase, StepFunction decrease, uint8_t numSteps, uint8_t value);
+  void valueByStepFunction(StepFunction increase, StepFunction decrease, uint8_t numSteps, uint8_t targetValue, int8_t knownValue = -1);
 
   virtual void initializePacket(uint8_t* packetStart) = 0;
   virtual void finalizePacket(uint8_t* packet);

--- a/lib/MiLightState/GroupState.h
+++ b/lib/MiLightState/GroupState.h
@@ -29,6 +29,12 @@ enum BulbMode {
   BULB_MODE_SCENE,
   BULB_MODE_NIGHT
 };
+
+enum class IncrementDirection : unsigned {
+  INCREASE = 1, 
+  DECREASE = -1U
+};
+
 static const char* BULB_MODE_NAMES[] = {
   "white",
   "color",
@@ -42,6 +48,12 @@ public:
   GroupState();
 
   bool isSetField(GroupStateField field) const;
+  uint16_t getFieldValue(GroupStateField field) const;
+  void setFieldValue(GroupStateField field, uint16_t value);
+
+  bool isSetScratchField(GroupStateField field) const;
+  uint16_t getScratchFieldValue(GroupStateField field) const;
+  void setScratchFieldValue(GroupStateField field, uint16_t value);
 
   // 1 bit
   bool isSetState() const;
@@ -105,6 +117,22 @@ public:
   void applyField(JsonObject& state, const BulbId& bulbId, GroupStateField field);
   void applyState(JsonObject& state, const BulbId& bulbId, GroupStateField* fields, size_t numFields);
 
+  // Attempt to keep track of increment commands in such a way that we can
+  // know what state it's in.  When we get an increment command (like "increase 
+  // brightness"):
+  //   1. If there is no value in the scratch state: assume real state is in 
+  //      the furthest value from the direction of the command.  For example, 
+  //      if we get "increase," assume the value was 0.
+  //   2. If there is a value in the scratch state, apply the command to it.
+  //      For example, if we get "decrease," subtract 1 from the scratch.
+  //   3. When scratch reaches a known extreme (either min or max), set the
+  //      persistent field to that value
+  //   4. If there is already a known value for the state, apply it rather
+  //      than messing with scratch state.
+  // 
+  // returns true if a (real, not scratch) state change was made
+  bool applyIncrementCommand(GroupStateField field, IncrementDirection dir);
+
   void load(Stream& stream);
   void dump(Stream& stream) const;
 
@@ -144,7 +172,21 @@ private:
     } fields;
   };
 
+  // Transient scratchpad that is never persisted.  Used to track and compute state for
+  // protocols that only have increment commands (like CCT).
+  union TransientData {
+    uint16_t rawData;
+    struct Fields {
+      uint16_t 
+        _isSetKelvinScratch     : 1,
+        _kelvinScratch          : 7,
+        _isSetBrightnessScratch : 1,
+        _brightnessScratch      : 8;
+    } fields;
+  };
+
   StateData state;
+  TransientData scratchpad;
 
   void applyColor(JsonObject& state, uint8_t r, uint8_t g, uint8_t b);
   void applyColor(JsonObject& state);

--- a/web/src/js/script.js
+++ b/web/src/js/script.js
@@ -280,6 +280,10 @@ var activeUrl = function() {
     groupId = 0;
   }
 
+  if (typeof groupId === "undefined") {
+    throw "Must enter group ID";
+  }
+
   return "/gateways/" + deviceId + "/" + mode + "/" + groupId;
 }
 


### PR DESCRIPTION
This adds the ability to keep track enough information to determine when CCT bulbs are in a known state.  This has a few advantages:

* Can report brightness and color temperature state values for CCT
* Only need to send the minimum number of increment/decrement commands after the bulb is in a known state (e.g., decrease once to go from brightness 60 to 50).