### PR TITLE
Fix blank webpage on root (ERR_INCOMPLETE_CHUNKED_ENCODING)

### DIFF
--- a/lib/WebServer/MiLightHttpServer.cpp
+++ b/lib/WebServer/MiLightHttpServer.cpp
@@ -478,10 +478,11 @@ void MiLightHttpServer::handlePacketSent(uint8_t *packet, const MiLightRemoteCon
 ESP8266WebServer::THandlerFunction MiLightHttpServer::handleServe_P(const char* data, size_t length) {
   return [this, data, length]() {
     server.sendHeader("Content-Encoding", "gzip");
-    server.sendHeader("Content-Length", String(length));
     server.setContentLength(CONTENT_LENGTH_UNKNOWN);
     server.send(200, "text/html", "");
     server.sendContent_P(data, length);
+    server.sendContent("");
     server.client().stop();
   };
 }
+


### PR DESCRIPTION
Regarding #264 blank webpage on root (ERR_INCOMPLETE_CHUNKED_ENCODING)

The content length was still set manually by the sendHeader call.

Also applied fix by sending an empty string just before closing the client socket:
https://www.esp8266.com/viewtopic.php?p=66764#p66875