### PR TITLE
Fix UDP v6 RgbCct color skew

### DIFF
--- a/lib/Udp/V6RgbCctCommandHandler.cpp
+++ b/lib/Udp/V6RgbCctCommandHandler.cpp
@@ -98,10 +98,6 @@ void V6RgbCctCommandHandler::handleUpdateColor(MiLightClient *client, uint32_t c
   for (int i = 3; i >= 0; i--) {
     const uint8_t argValue = (color >> (i*8)) & 0xFF;
 
-    if (argValue == 0) {
-      return;
-    }
-
-    client->updateColorRaw(argValue);
+    client->updateColorRaw(argValue + 0xF6);
   }
 }


### PR DESCRIPTION
This fixes #319 for me and UDP messages now set the same colors as my iBox.

I assume the call in the preset method would need to be similarly adjusted but I have no way of testing that at this time and I would like some feedback before spending more time on this.