### PR TITLE
Fix broken build due to upstream platform changes

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -16,8 +16,7 @@ lib_deps_builtin =
   SPI
 lib_deps_external =
   sidoh/RF24
-;  WiFiManager
-  https://github.com/cmidgley/WiFiManager
+  sidoh/WiFiManager#cmidgley
   ArduinoJson
   PubSubClient
   https://github.com/ratkins/RGBConverter

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,7 +10,7 @@
 
 [common]
 framework = arduino
-platform = https://github.com/platformio/platform-espressif8266.git
+platform = espressif8266@~1.8.0
 board_f_cpu = 160000000L
 lib_deps_builtin =
   SPI


### PR DESCRIPTION
Changes:

* Fix major/minor platform version.  Should help prevent this kind of stuff in the future.
* Use my fork of WiFiManager, which pulls @cmidgley's feature and fixes from origin.

Context in this comment: https://github.com/sidoh/esp8266_milight_hub/pull/333#issuecomment-419732949

@jnordberg FYI