### PR TITLE
Fix change of LED pin setting

### DIFF
--- a/lib/LEDStatus/LEDStatus.cpp
+++ b/lib/LEDStatus/LEDStatus.cpp
@@ -27,7 +27,7 @@ void LEDStatus::changePin(int8_t ledPin) {
     inverse = false;
   }
 
-  if ((ledPin != _ledPin) && (inverse != _inverse)) {
+  if ((ledPin != _ledPin) || (inverse != _inverse)) {
     // make sure old pin is off
     digitalWrite(_ledPin, _pinState(LOW));
     _ledPin = ledPin;


### PR DESCRIPTION
A change to `ledPin` would only have an effect if `inverse` was also change (and vice versa).

...

I found this while trying to figure out why I was unable to completely turn off the LED. It turns out that my board has two LEDs and I was observing the wrong one. The one I was trying to silence would actually light up every time a packet was sent because it is controlled by GPIO16. Moving CE from GPIO16 to GPIO4 solved my issue.

https://lowvoltage.github.io/2017/07/09/Onboard-LEDs-NodeMCU-Got-Two