### PR TITLE
Fix crash when sending group 0 commands

### DIFF
--- a/lib/MiLight/FUT089PacketFormatter.cpp
+++ b/lib/MiLight/FUT089PacketFormatter.cpp
@@ -35,18 +35,22 @@ void FUT089PacketFormatter::updateColorRaw(uint8_t value) {
 void FUT089PacketFormatter::updateTemperature(uint8_t value) {
   // look up our current mode 
   const GroupState* ourState = this->stateStore->get(this->deviceId, this->groupId, REMOTE_TYPE_FUT089);
-  BulbMode originalBulbMode = ourState->getBulbMode();
+  BulbMode originalBulbMode;
+  
+  if (ourState != NULL) {
+    originalBulbMode = ourState->getBulbMode();
 
-  // are we already in white?  If not, change to white
-  if (originalBulbMode != BulbMode::BULB_MODE_WHITE) {
-    updateColorWhite();
+    // are we already in white?  If not, change to white
+    if (originalBulbMode != BulbMode::BULB_MODE_WHITE) {
+      updateColorWhite();
+    }
   }
 
   // now make the temperature change
   command(FUT089_KELVIN, 100 - value);
 
   // and return to our original mode
-  if ((settings->enableAutomaticModeSwitching) && (originalBulbMode != BulbMode::BULB_MODE_WHITE)) {
+  if (ourState != NULL && (settings->enableAutomaticModeSwitching) && (originalBulbMode != BulbMode::BULB_MODE_WHITE)) {
     switchMode(*ourState, originalBulbMode);
   }
 }
@@ -58,10 +62,14 @@ void FUT089PacketFormatter::updateTemperature(uint8_t value) {
 void FUT089PacketFormatter::updateSaturation(uint8_t value) {
   // look up our current mode 
   const GroupState* ourState = this->stateStore->get(this->deviceId, this->groupId, REMOTE_TYPE_FUT089);
-  BulbMode originalBulbMode = ourState->getBulbMode();
+  BulbMode originalBulbMode;
+  
+  if (ourState != NULL) {
+    originalBulbMode = ourState->getBulbMode();
+  }
 
   // are we already in color?  If not, we need to flip modes
-  if ((settings->enableAutomaticModeSwitching) && (originalBulbMode != BulbMode::BULB_MODE_COLOR)) {
+  if (ourState != NULL && (settings->enableAutomaticModeSwitching) && (originalBulbMode != BulbMode::BULB_MODE_COLOR)) {
     updateHue(ourState->getHue());
   }
 
@@ -69,7 +77,7 @@ void FUT089PacketFormatter::updateSaturation(uint8_t value) {
   command(FUT089_SATURATION, 100 - value);
 
   // and revert back if necessary
-  if ((settings->enableAutomaticModeSwitching) && (originalBulbMode != BulbMode::BULB_MODE_COLOR)) {
+  if (ourState != NULL && (settings->enableAutomaticModeSwitching) && (originalBulbMode != BulbMode::BULB_MODE_COLOR)) {
     switchMode(*ourState, originalBulbMode);
   }
 }

--- a/lib/MiLight/RgbPacketFormatter.cpp
+++ b/lib/MiLight/RgbPacketFormatter.cpp
@@ -48,7 +48,7 @@ void RgbPacketFormatter::updateColorRaw(uint8_t value) {
 
 void RgbPacketFormatter::updateBrightness(uint8_t value) {
   const GroupState* state = this->stateStore->get(deviceId, groupId, MiLightRemoteType::REMOTE_TYPE_RGB);
-  int8_t knownValue = state->isSetBrightness() ? state->getBrightness() : -1;
+  int8_t knownValue = (state != NULL && state->isSetBrightness()) ? state->getBrightness() : -1;
 
   valueByStepFunction(
     &PacketFormatter::increaseBrightness,

--- a/lib/MiLight/RgbwPacketFormatter.cpp
+++ b/lib/MiLight/RgbwPacketFormatter.cpp
@@ -44,7 +44,7 @@ void RgbwPacketFormatter::previousMode() {
 
 uint8_t RgbwPacketFormatter::currentMode() {
   const GroupState* state = stateStore->get(deviceId, groupId, REMOTE_TYPE_RGBW);
-  return state->getMode();
+  return state != NULL ? state->getMode() : 0;
 }
 
 void RgbwPacketFormatter::updateMode(uint8_t mode) {

--- a/lib/Udp/V6RgbCctCommandHandler.cpp
+++ b/lib/Udp/V6RgbCctCommandHandler.cpp
@@ -36,8 +36,6 @@ bool V6RgbCctCommandHandler::handleCommand(
 
   client->setHeld((command & 0x80) == 0x80);
 
-  Serial.println("check1");
-
   if (cmd == V2_STATUS) {
     switch (arg) {
       case V2_RGB_CCT_ON:
@@ -64,17 +62,13 @@ bool V6RgbCctCommandHandler::handleCommand(
     return true;
   }
 
-  Serial.println("check2");
-
   switch (cmd) {
     case V2_COLOR:
       handleUpdateColor(client, commandArg);
       break;
 
     case V2_KELVIN:
-    Serial.println("check3");
       client->updateTemperature(100 - arg);
-    Serial.println("check4");
       break;
 
     case V2_BRIGHTNESS:

--- a/lib/Udp/V6RgbCctCommandHandler.cpp
+++ b/lib/Udp/V6RgbCctCommandHandler.cpp
@@ -36,6 +36,8 @@ bool V6RgbCctCommandHandler::handleCommand(
 
   client->setHeld((command & 0x80) == 0x80);
 
+  Serial.println("check1");
+
   if (cmd == V2_STATUS) {
     switch (arg) {
       case V2_RGB_CCT_ON:
@@ -62,13 +64,17 @@ bool V6RgbCctCommandHandler::handleCommand(
     return true;
   }
 
+  Serial.println("check2");
+
   switch (cmd) {
     case V2_COLOR:
       handleUpdateColor(client, commandArg);
       break;
 
     case V2_KELVIN:
+    Serial.println("check3");
       client->updateTemperature(100 - arg);
+    Serial.println("check4");
       break;
 
     case V2_BRIGHTNESS:


### PR DESCRIPTION
Several places that relied on non-null state existing would cause crashes.  This change fixes that behavior.