### PR TITLE
Implements static IP for wifimanager (caveat in PR)

### DIFF
--- a/lib/Settings/Settings.cpp
+++ b/lib/Settings/Settings.cpp
@@ -139,6 +139,10 @@ void Settings::patch(JsonObject& parsedSettings) {
       JsonArray& arr = parsedSettings["group_state_fields"];
       updateGroupStateFields(arr);
     }
+
+    this->setIfPresent<String>(parsedSettings, "wifi_static_ip", wifiStaticIP);
+    this->setIfPresent<String>(parsedSettings, "wifi_static_ip_gateway", wifiStaticIPGateway);
+    this->setIfPresent<String>(parsedSettings, "wifi_static_ip_netmask", wifiStaticIPNetmask);
   }
 }
 
@@ -233,6 +237,10 @@ void Settings::serialize(Stream& stream, const bool prettyPrint) {
 
     root["group_state_fields"] = arr;
   }
+
+  root["wifi_static_ip"] = this->wifiStaticIP;
+  root["wifi_static_ip_gateway"] = this->wifiStaticIPGateway;
+  root["wifi_static_ip_netmask"] = this->wifiStaticIPNetmask;
 
   if (prettyPrint) {
     root.prettyPrintTo(stream);

--- a/lib/Settings/Settings.h
+++ b/lib/Settings/Settings.h
@@ -98,7 +98,10 @@ public:
     ledModeWifiFailed(LEDStatus::LEDMode::On),
     ledModeOperating(LEDStatus::LEDMode::SlowBlip),
     ledModePacket(LEDStatus::LEDMode::Flicker),
-    ledModePacketCount(3)
+    ledModePacketCount(3),
+    wifiStaticIP("0.0.0.0"),
+    wifiStaticIPNetmask("0.0.0.0"),
+    wifiStaticIPGateway("0.0.0.0")
   {
     if (groupStateFields == NULL) {
       numGroupStateFields = size(DEFAULT_GROUP_STATE_FIELDS);
@@ -167,6 +170,9 @@ public:
   LEDStatus::LEDMode ledModeOperating;
   LEDStatus::LEDMode ledModePacket;
   size_t ledModePacketCount;
+  String wifiStaticIP;
+  String wifiStaticIPNetmask;
+  String wifiStaticIPGateway;
 
 
 protected:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,6 +24,10 @@
 #include <LEDStatus.h>
 
 WiFiManager wifiManager;
+// because of callbacks, these need to be in the higher scope :(
+WiFiManagerParameter* wifiStaticIP = NULL;
+WiFiManagerParameter* wifiStaticIPNetmask = NULL;
+WiFiManagerParameter* wifiStaticIPGateway = NULL;
 
 static LEDStatus *ledStatus;
 
@@ -262,6 +266,16 @@ void handleLED() {
   ledStatus->handle();
 }
 
+void wifiExtraSettingsChange() {
+  WiFiManagerParameter param = *wifiStaticIP;
+  settings.wifiStaticIP = param.getValue();
+  param = *wifiStaticIPNetmask;
+  settings.wifiStaticIPNetmask = param.getValue();
+  param = *wifiStaticIPGateway;
+  settings.wifiStaticIPGateway = param.getValue();
+  settings.save();
+}
+
 void setup() {
   Serial.begin(9600);
   String ssid = "ESP" + String(ESP.getChipId());
@@ -285,6 +299,36 @@ void setup() {
   // that change is only on the development branch so we are going to continue to use this fork until
   // that is merged and ready.
   wifiManager.setSetupLoopCallback(handleLED);
+  
+  // Allows us to have static IP config in the captive portal. Yucky pointers to pointers, just to have the settings carry through
+  wifiManager.setSaveConfigCallback(wifiExtraSettingsChange);
+  char* _value = new char[14];
+  settings.wifiStaticIP.toCharArray(_value,14);
+  WiFiManagerParameter param = WiFiManagerParameter("staticIP", "Static IP (Leave 0.0.0.0 for dhcp)", _value, 15);
+  wifiStaticIP = &param;
+  wifiManager.addParameter(wifiStaticIP);
+  char* _value2 = new char[14];
+  settings.wifiStaticIPNetmask.toCharArray(_value2,14);
+  WiFiManagerParameter param2 = WiFiManagerParameter("netmask", "Netmask (required if IP given)", _value2, 15);
+  wifiStaticIPNetmask = &param2;
+  wifiManager.addParameter(wifiStaticIPNetmask);
+  char* _value3 = new char[14];
+  settings.wifiStaticIPGateway.toCharArray(_value3,14);
+  WiFiManagerParameter param3 = WiFiManagerParameter("gateway", "Default Gateway (optional, only used if static IP)", _value3, 15);
+  wifiStaticIPGateway = &param3;
+  wifiManager.addParameter(wifiStaticIPGateway);
+
+  // We have a saved static IP, let's try and use it.
+  if (settings.wifiStaticIP != "0.0.0.0") {
+    Serial.println(F("We have a static IP.\n"));
+    Serial.println(settings.wifiStaticIP + "\n");
+    IPAddress _ip,_subnet,_gw;
+    _ip.fromString(settings.wifiStaticIP);
+    _subnet.fromString(settings.wifiStaticIPNetmask);
+    _gw.fromString(settings.wifiStaticIPGateway);
+    wifiManager.setSTAStaticIPConfig(_ip,_gw,_subnet);
+  }
+
   wifiManager.setConfigPortalTimeout(180);
   if (wifiManager.autoConnect(ssid.c_str(), "milightHub")) {
     // set LED mode for successful operation


### PR DESCRIPTION
Adds configuration for static IP in wifiManager, stored in milight_hub's settings.

Caveats: 

- First, this will still attempt a DHCP request on "save" from the captive portal.  Without "fixing" the wifimanager's handling of saving (it kinda doesn't really) the static IP, it's not really possible to deal with both DHCP and static config.  It works after a reset, but not immediately after "save".

- Second, the wifiManager fork we're using already has functionality for static IP _OR_ DHCP but not both modes and this leads to an interesting scenario :
  - If the device is set to static IP, and then the user uses the admin function to reset wifi, when the captive portal comes up it will have 6 inputs instead of 3 and confuse the hell out of the user!
  - I suggest removing entirely this if block from the fork of wifimanager we're using : https://github.com/tzapu/WiFiManager/blob/master/WiFiManager.cpp#L553

- Third, and this is just me being annoyed at HTML, on a lot of mobile browsers you never see the "placeholder" text.  That means three blank boxes.
   - I suggest in the wifimanager fork around https://github.com/tzapu/WiFiManager/blob/master/WiFiManager.h#L32 that we add the following to the definition of HTTP_FORM_PARAM[] : `<label for={i}>{p}</label><input id={i}...` which works fine (tested here) and makes the form usable on those older/different browsers.

Oh and yeah, the pointer to pointer and multiple char arrays stuff is inefficient and yucky, but the callback doesn't pass anything back and I'm rusty on c/c++ around memory management so I'm extra careful and it just ends up looking messy but works.  Happy for anyone to refactor that or even just use this as a base for a completely different fork.  I'm happy as this is working on my Wemos fine :-)