### PR TITLE
Improve NRF24L01+ pin configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Both modules are SPI devices and should be connected to the standard SPI pins on
 
 ##### NRF24L01+
 
-[This guide](https://www.mysensors.org/build/connect_radio#nrf24l01+-&-esp8266) details how to connect an NRF24 to an ESP8266. I used GPIO 16 for CE and GPIO 15 for CSN instead. These can be configured later.
+[This guide](https://www.mysensors.org/build/connect_radio#nrf24l01+-&-esp8266) details how to connect an NRF24 to an ESP8266. By default GPIO 16 for CE and GPIO 15 for CSN are configured but these can be configured later. When following the guide to connect the antenna make sure to change "CE / PKT pin" from 16 to 4.
 
 ##### LT8900
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Both modules are SPI devices and should be connected to the standard SPI pins on
 
 ##### NRF24L01+
 
-[This guide](https://www.mysensors.org/build/connect_radio#nrf24l01+-&-esp8266) details how to connect an NRF24 to an ESP8266. By default GPIO 16 for CE and GPIO 15 for CSN are configured but these can be configured later. When following the guide to connect the antenna make sure to change "CE / PKT pin" from 16 to 4.
+[This guide](https://www.mysensors.org/build/connect_radio#nrf24l01+-&-esp8266) details how to connect an NRF24 to an ESP8266. By default GPIO 16 for CE and GPIO 15 for CSN are used, but these can be configured later. When following the guide to connect the antenna, make sure to change "CE / PKT pin" from 4 to 16.
 
 ##### LT8900
 


### PR DESCRIPTION
Because of the explicit link to this guide I kind of assumed the right pin was used by default which is not the case. The guide puts the CE pin on GPIO 4, not GPIO 16. Maybe it will save others some time if this was added to the readme.