### PR TITLE
Change default CE pin from 16 to 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Both modules are SPI devices and should be connected to the standard SPI pins on
 
 ##### LT8900
 
-Connect SPI pins (CS, SCK, MOSI, MISO) to appropriate SPI pins on the ESP8266. With default settings, connect RST to GPIO 0, and PKT to GPIO 16. By default GPIO 4 for CE and GPIO 15 for CSN are used, make sure to properly configure these.
+Connect SPI pins (CE, SCK, MOSI, MISO) to appropriate SPI pins on the ESP8266. With default settings, connect RST to GPIO 0, PKT to GPIO 16, CE to GPIO 4, and CSN to GPIO 15.  Make sure to properly configure these if using non-default pinouts.
 
 #### Setting up the ESP
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Both modules are SPI devices and should be connected to the standard SPI pins on
 
 ##### NRF24L01+
 
-[This guide](https://www.mysensors.org/build/connect_radio#nrf24l01+-&-esp8266) details how to connect an NRF24 to an ESP8266. By default GPIO 16 for CE and GPIO 15 for CSN are used, but these can be configured later. When following the guide to connect the antenna, make sure to change "CE / PKT pin" from 4 to 16.
+[This guide](https://www.mysensors.org/build/connect_radio#nrf24l01+-&-esp8266) details how to connect an NRF24 to an ESP8266. By default GPIO 16 for CE and GPIO 15 for CSN are used, but these can be configured later.
 
 ##### LT8900
 

--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@ Both modules are SPI devices and should be connected to the standard SPI pins on
 
 ##### NRF24L01+
 
-[This guide](https://www.mysensors.org/build/connect_radio#nrf24l01+-&-esp8266) details how to connect an NRF24 to an ESP8266. By default GPIO 16 for CE and GPIO 15 for CSN are used, but these can be configured later.
+[This guide](https://www.mysensors.org/build/connect_radio#nrf24l01+-&-esp8266) details how to connect an NRF24 to an ESP8266. By default GPIO 4 for CE and GPIO 15 for CSN are used, but these can be configured later.
 
 ##### LT8900
 
-Connect SPI pins (CS, SCK, MOSI, MISO) to appropriate SPI pins on the ESP8266. With default settings, connect RST to GPIO 0, and PKT to GPIO 16.
+Connect SPI pins (CS, SCK, MOSI, MISO) to appropriate SPI pins on the ESP8266. With default settings, connect RST to GPIO 0, and PKT to GPIO 16. By default GPIO 4 for CE and GPIO 15 for CSN are used, make sure to properly configure these.
 
 #### Setting up the ESP
 

--- a/lib/Settings/Settings.h
+++ b/lib/Settings/Settings.h
@@ -72,7 +72,7 @@ public:
     adminUsername(""),
     adminPassword(""),
     // CE and CSN pins from nrf24l01
-    cePin(16),
+    cePin(4),
     csnPin(15),
     resetPin(0),
     ledPin(-2),


### PR DESCRIPTION
Turns out I didn't properly read your proposed changes in #367 as currently the description is "from 4 to 16" while it should be the other way around. The default is set to GPIO 16 and it needs to be changed to GPIO 4 to work when following the linked guide to install the antenna. As you stated there is no real reason GPIO 16 is picked by default I think it would save others some headaches (just like me) if it changed to GPIO 4. I've also removed the additional copy added to the README.md as this was wrong and correcting it would no longer be required.