### PR TITLE
Improvements in group 0 behavior

### DIFF
--- a/lib/MiLight/MiLightClient.cpp
+++ b/lib/MiLight/MiLightClient.cpp
@@ -429,6 +429,9 @@ void MiLightClient::update(const JsonObject& request) {
   if (request.containsKey("temperature")) {
     this->updateTemperature(request["temperature"]);
   }
+  if (request.containsKey("kelvin")) {
+    this->updateTemperature(request["kelvin"]);
+  }
   // HomeAssistant
   if (request.containsKey("color_temp")) {
     this->updateTemperature(

--- a/lib/MiLightState/GroupState.cpp
+++ b/lib/MiLightState/GroupState.cpp
@@ -137,6 +137,66 @@ void GroupState::print(Stream& stream) const {
   stream.printf("State: %08X %08X\n", state.rawData[0], state.rawData[1]);
 }
 
+bool GroupState::clearField(GroupStateField field) {
+  bool clearedAny = false;
+
+  switch (field) {
+    // Always set and can't be cleared
+    case GroupStateField::COMPUTED_COLOR:
+    case GroupStateField::DEVICE_ID:
+    case GroupStateField::GROUP_ID:
+    case GroupStateField::DEVICE_TYPE:
+      break;
+
+    case GroupStateField::STATE:
+    case GroupStateField::STATUS:
+      clearedAny = isSetState();
+      state.fields._isSetState = 0;
+      break;
+
+    case GroupStateField::BRIGHTNESS:
+    case GroupStateField::LEVEL:
+      clearedAny = clearBrightness();
+      break;
+
+    case GroupStateField::COLOR:
+    case GroupStateField::HUE:
+    case GroupStateField::OH_COLOR:
+      clearedAny = isSetHue();
+      state.fields._isSetHue = 0;
+      break;
+
+    case GroupStateField::SATURATION:
+      clearedAny = isSetSaturation();
+      state.fields._isSetSaturation = 0;
+      break;
+
+    case GroupStateField::MODE:
+    case GroupStateField::EFFECT:
+      clearedAny = isSetMode();
+      state.fields._isSetMode = 0;
+      break;
+
+    case GroupStateField::KELVIN:
+    case GroupStateField::COLOR_TEMP:
+      clearedAny = isSetKelvin();
+      state.fields._isSetKelvin = 0;
+      break;
+
+    case GroupStateField::BULB_MODE:
+      clearedAny = isSetBulbMode();
+      state.fields._isSetBulbMode = 0;
+
+      // Clear brightness as well
+      Serial.println("also clearing brightness");
+      clearedAny = clearBrightness() || clearedAny;
+      debugState("result--");
+      break;
+  }
+
+  return clearedAny;
+}
+
 bool GroupState::isSetField(GroupStateField field) const {
   switch (field) {
     case GroupStateField::COMPUTED_COLOR:
@@ -312,6 +372,33 @@ bool GroupState::isSetBrightness() const {
   }
 
   return false;
+}
+bool GroupState::clearBrightness() {
+  bool cleared = false;
+
+  if (!state.fields._isSetBulbMode) {
+    cleared = state.fields._isSetBrightness;
+    state.fields._isSetBrightness = 0;
+  } else {
+    switch (state.fields._bulbMode) {
+      case BULB_MODE_COLOR:
+        cleared = state.fields._isSetBrightnessColor;
+        state.fields._isSetBrightnessColor = 0;
+        break;
+
+      case BULB_MODE_SCENE:
+        cleared = state.fields._isSetBrightnessMode;
+        state.fields._isSetBrightnessMode = 0;
+        break;
+
+      case BULB_MODE_WHITE:
+        cleared = state.fields._isSetBrightness;
+        state.fields._isSetBrightness = 0;
+        break;
+    }
+  }
+
+  return cleared;
 }
 uint8_t GroupState::getBrightness() const {
   switch (state.fields._bulbMode) {
@@ -539,6 +626,31 @@ bool GroupState::applyIncrementCommand(GroupStateField field, IncrementDirection
   }
 
   return false;
+}
+
+bool GroupState::clearNonMatchingFields(const GroupState& other) {
+#ifdef STATE_DEBUG
+  this->debugState("Clearing fields.  Current state");
+  other.debugState("Other state");
+#endif
+
+  bool clearedAny = false;
+
+  for (size_t i = 0; i < size(ALL_PHYSICAL_FIELDS); ++i) {
+    GroupStateField field = ALL_PHYSICAL_FIELDS[i];
+
+    if (other.isSetField(field) && isSetField(field) && getFieldValue(field) != other.getFieldValue(field)) {
+      if (clearField(field)) {
+        clearedAny = true;
+      }
+    }
+  }
+
+#ifdef STATE_DEBUG
+  this->debugState("Result");
+#endif
+
+  return clearedAny;
 }
 
 bool GroupState::patch(const GroupState& other) {

--- a/lib/MiLightState/GroupState.cpp
+++ b/lib/MiLightState/GroupState.cpp
@@ -358,7 +358,11 @@ bool GroupState::setState(const MiLightStatus status) {
 }
 
 bool GroupState::isSetBrightness() const {
-  if (! state.fields._isSetBulbMode) {
+  // If we don't know what mode we're in, just assume white mode.  Do this for a few
+  // reasons:
+  //   * Some bulbs don't have multiple modes
+  //   * It's confusing to not have a default
+  if (! isSetBulbMode()) {
     return state.fields._isSetBrightness;
   }
 
@@ -838,7 +842,7 @@ void GroupState::applyField(JsonObject& partialState, const BulbId& bulbId, Grou
       case GroupStateField::EFFECT:
         if (getBulbMode() == BULB_MODE_SCENE) {
           partialState["effect"] = String(getMode());
-        } else if (getBulbMode() == BULB_MODE_WHITE) {
+        } else if (isSetBulbMode() && getBulbMode() == BULB_MODE_WHITE) {
           partialState["effect"] = "white_mode";
         } else if (getBulbMode() == BULB_MODE_NIGHT) {
           partialState["effect"] = "night_mode";
@@ -846,13 +850,13 @@ void GroupState::applyField(JsonObject& partialState, const BulbId& bulbId, Grou
         break;
 
       case GroupStateField::COLOR_TEMP:
-        if (getBulbMode() == BULB_MODE_WHITE) {
+        if (isSetBulbMode() && getBulbMode() == BULB_MODE_WHITE) {
           partialState["color_temp"] = getMireds();
         }
         break;
 
       case GroupStateField::KELVIN:
-        if (getBulbMode() == BULB_MODE_WHITE) {
+        if (isSetBulbMode() && getBulbMode() == BULB_MODE_WHITE) {
           partialState["kelvin"] = getKelvin();
         }
         break;

--- a/lib/MiLightState/GroupState.cpp
+++ b/lib/MiLightState/GroupState.cpp
@@ -69,6 +69,15 @@ bool BulbId::operator==(const BulbId &other) {
 }
 
 GroupState::GroupState() {
+  initFields();
+}
+
+GroupState::GroupState(const JsonObject& jsonState) {
+  initFields();
+  patch(jsonState);
+}
+
+void GroupState::initFields() {
   state.fields._state                = 0;
   state.fields._brightness           = 0;
   state.fields._brightnessColor      = 0;

--- a/lib/MiLightState/GroupState.cpp
+++ b/lib/MiLightState/GroupState.cpp
@@ -188,9 +188,7 @@ bool GroupState::clearField(GroupStateField field) {
       state.fields._isSetBulbMode = 0;
 
       // Clear brightness as well
-      Serial.println("also clearing brightness");
       clearedAny = clearBrightness() || clearedAny;
-      debugState("result--");
       break;
   }
 

--- a/lib/MiLightState/GroupState.h
+++ b/lib/MiLightState/GroupState.h
@@ -49,14 +49,19 @@ public:
   GroupState(const GroupState& other);
   GroupState& operator=(const GroupState& other);
 
+  // Convenience constructor that patches defaults with JSON state
+  GroupState(const JsonObject& jsonState);
+
+  void initFields();
+
   bool operator==(const GroupState& other) const;
   bool isEqualIgnoreDirty(const GroupState& other) const;
   void print(Stream& stream) const;
 
-
   bool isSetField(GroupStateField field) const;
   uint16_t getFieldValue(GroupStateField field) const;
   void setFieldValue(GroupStateField field, uint16_t value);
+  bool clearField(GroupStateField field);
 
   bool isSetScratchField(GroupStateField field) const;
   uint16_t getScratchFieldValue(GroupStateField field) const;
@@ -73,6 +78,7 @@ public:
   bool isSetBrightness() const;
   uint8_t getBrightness() const;
   bool setBrightness(uint8_t brightness);
+  bool clearBrightness();
 
   // 8 bits
   bool isSetHue() const;
@@ -114,6 +120,10 @@ public:
   bool isMqttDirty() const;
   inline bool setMqttDirty();
   bool clearMqttDirty();
+
+  // Clears all of the fields in THIS GroupState that have different values
+  // than the provided group state.
+  bool clearNonMatchingFields(const GroupState& other);
 
   // Patches this state with ONLY the set fields in the other. Returns 
   // true if there were any changes.

--- a/lib/MiLightState/GroupStateStore.cpp
+++ b/lib/MiLightState/GroupStateStore.cpp
@@ -10,26 +10,17 @@ GroupStateStore::GroupStateStore(const size_t maxSize, const size_t flushRate)
 GroupState* GroupStateStore::get(const BulbId& id) {
   GroupState* state = cache.get(id);
 
-  // Always force re-initialization of group 0 state
-  if (id.groupId == 0 || state == NULL) {
+  if (state == NULL) {
     trackEviction();
     GroupState loadedState = GroupState::defaultState(id.deviceType);
 
-    // For device types with groups, group 0 is a "virtual" group.  All devices paired with the same ID will respond
-    // to group 0.  So it doesn't make sense to store group 0 state by itself.
-    //
-    // For devices that don't have groups, we made the unfortunate decision to represent state using the fake group
-    // ID 0, so we can't always ignore group 0.
     const MiLightRemoteConfig* remoteConfig = MiLightRemoteConfig::fromType(id.deviceType);
 
     if (remoteConfig == NULL) {
       return NULL;
     }
 
-    if (id.groupId != 0 || remoteConfig->numGroups == 0) {
-      persistence.get(id, loadedState);
-    }
-
+    persistence.get(id, loadedState);
     state = cache.set(id, loadedState);
   }
 
@@ -41,15 +32,23 @@ GroupState* GroupStateStore::get(const uint16_t deviceId, const uint8_t groupId,
   return get(bulbId);
 }
 
-// save state for a bulb.  If id.groupId == 0, will iterate across all groups
-// and individually save each group (recursively)
+// Save state for a bulb.
+//
+// Notes:
+//
+// * For device types with groups, group 0 is a "virtual" group.  All devices paired with the same ID will 
+//   respond to group 0.  When state for an individual (i.e., != 0) group is changed, the state for 
+//   group 0 becomes out of sync and should be cleared.
+//
+// * If id.groupId == 0, will iterate across all groups and individually save each group (recursively)
+//
 GroupState* GroupStateStore::set(const BulbId &id, const GroupState& state) {
+  BulbId otherId(id);
   GroupState* storedState = get(id);
-  *storedState = state;
+  storedState->patch(state);
 
   if (id.groupId == 0) {
     const MiLightRemoteConfig* remote = MiLightRemoteConfig::fromType(id.deviceType);
-    BulbId individualBulb(id);
 
 #ifdef STATE_DEBUG
     Serial.printf_P(PSTR("Fanning out group 0 state for device ID 0x%04X (%d groups in total)\n"), id.deviceId, remote->numGroups);
@@ -57,11 +56,16 @@ GroupState* GroupStateStore::set(const BulbId &id, const GroupState& state) {
 #endif
 
     for (size_t i = 1; i <= remote->numGroups; i++) {
-      individualBulb.groupId = i;
+      otherId.groupId = i;
 
-      GroupState* individualState = get(individualBulb);
+      GroupState* individualState = get(otherId);
       individualState->patch(state);
     }
+  } else {
+    otherId.groupId = 0;
+    GroupState* group0State = get(otherId);
+
+    group0State->clearNonMatchingFields(state);
   }
   
   return storedState;
@@ -70,6 +74,14 @@ GroupState* GroupStateStore::set(const BulbId &id, const GroupState& state) {
 GroupState* GroupStateStore::set(const uint16_t deviceId, const uint8_t groupId, const MiLightRemoteType deviceType, const GroupState& state) {
   BulbId bulbId(deviceId, groupId, deviceType);
   return set(bulbId, state);
+}
+
+void GroupStateStore::clear(const BulbId& bulbId) {
+  GroupState* state = get(bulbId);
+
+  if (state != NULL) {
+    state->initFields();
+  }
 }
 
 void GroupStateStore::trackEviction() {

--- a/lib/MiLightState/GroupStateStore.h
+++ b/lib/MiLightState/GroupStateStore.h
@@ -26,6 +26,8 @@ public:
   GroupState* set(const BulbId& id, const GroupState& state);
   GroupState* set(const uint16_t deviceId, const uint8_t groupId, const MiLightRemoteType deviceType, const GroupState& state);
 
+  void clear(const BulbId& id);
+
   /*
    * Flushes all states to persistent storage.  Returns true iff anything was
    * flushed.

--- a/lib/WebServer/MiLightHttpServer.h
+++ b/lib/WebServer/MiLightHttpServer.h
@@ -57,6 +57,7 @@ protected:
   void handleListenGateway(const UrlTokenBindings* urlBindings);
   void handleSendRaw(const UrlTokenBindings* urlBindings);
   void handleUpdateGroup(const UrlTokenBindings* urlBindings);
+  void handleDeleteGroup(const UrlTokenBindings* urlBindings);
   void handleGetGroup(const UrlTokenBindings* urlBindings);
 
   void handleRequest(const JsonObject& request);

--- a/platformio.ini
+++ b/platformio.ini
@@ -24,7 +24,8 @@ lib_deps_external =
   CircularBuffer@~1.2.0
 extra_scripts =
   pre:.build_web.py
-build_flags = !python .get_version.py -DMQTT_MAX_PACKET_SIZE=200 -DHTTP_UPLOAD_BUFLEN=128 -D FIRMWARE_NAME=milight-hub -Idist -Ilib/DataStructures
+build_flags = !python .get_version.py -DMQTT_MAX_PACKET_SIZE=200 -DHTTP_UPLOAD_BUFLEN=128 -D FIRMWARE_NAME=milight-hub -Idist -Ilib/DataStructures 
+# -D STATE_DEBUG
 # -D DEBUG_PRINTF
 # -D MQTT_DEBUG
 # -D MILIGHT_UDP_DEBUG

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -109,12 +109,13 @@ void onPacketSentHandler(uint8_t* packet, const MiLightRemoteConfig& config) {
 
   // update state to reflect changes from this packet
   GroupState* groupState = stateStore->get(bulbId);
+  const GroupState stateUpdates(result);
 
   if (groupState != NULL) {
-    groupState->patch(result);
+    groupState->patch(stateUpdates);
 
     // Copy state before setting it to avoid group 0 re-initialization clobbering it
-    stateStore->set(bulbId, GroupState(*groupState));
+    stateStore->set(bulbId, stateUpdates);
   }
 
   if (mqttClient) {

--- a/test/remote/helpers/state_helpers.rb
+++ b/test/remote/helpers/state_helpers.rb
@@ -1,0 +1,6 @@
+module StateHelpers
+  def states_are_equal(desired_state, retrieved_state)
+    expect(retrieved_state).to include(*desired_state.keys)
+    expect(retrieved_state.select { |x| desired_state.include?(x) } ).to eq(desired_state)
+  end
+end

--- a/test/remote/lib/api_client.rb
+++ b/test/remote/lib/api_client.rb
@@ -74,11 +74,23 @@ class ApiClient
     request(:Post, path, body)
   end
 
+  def delete(path)
+    request(:Delete, path)
+  end
+
+  def state_path(params = {})
+    "/gateways/#{params[:id]}/#{params[:type]}/#{params[:group_id]}"
+  end
+
+  def delete_state(params = {})
+    delete(state_path(params))
+  end
+
   def get_state(params = {})
-    get("/gateways/#{params[:id]}/#{params[:type]}/#{params[:group_id]}")
+    get(state_path(params))
   end
 
   def patch_state(state, params = {})
-    put("/gateways/#{params[:id]}/#{params[:type]}/#{params[:group_id]}", state.to_json)
+    put(state_path(params), state.to_json)
   end
 end


### PR DESCRIPTION
This change makes interplay between group 0 (the "all" group) and member groups more intuitive.

Previously, behavior was simple, but caused confusion when users expected group 0 to track its own state (e.g., #318).  Since 1.8, group 0 state was not tracked (#284).

This change makes the interplay more complex, but hopefully more intuitive.

## Summary

* Group 0 will have its own state.  As was the case previously, applying a change to group 0 will fan out to individual groups.
* When an individual group changes a field, group 0 state for that field will be cleared.

## Example

#### Group 0 is fanned out

```
$ curl -H 'content-type: application/json' -X PUT -d '{"status":"on","level":10,"kelvin":100}' milight-hub/gateways/0x2200/rgb_cct/0

$ curl milight-hub/gateways/0x2200/rgb_cct/0
{"status":"ON","level":10,"kelvin":100,"bulb_mode":"white","effect":"white_mode"}

$ curl milight-hub/gateways/0x2200/rgb_cct/1
{"status":"ON","level":10,"kelvin":100,"bulb_mode":"white","effect":"white_mode"}

$ curl milight-hub/gateways/0x2200/rgb_cct/2
{"status":"ON","level":10,"kelvin":100,"bulb_mode":"white","effect":"white_mode"}
```
#### Updating `kelvin` for Group 1 clears `kelvin` for Group 0

```
$ curl -H 'content-type: application/json' -X PUT -d '{"kelvin":10}' milight-hub/gateways/0x2200/rgb_cct/1

$ curl milight-hub/gateways/0x2200/rgb_cct/0
{"status":"ON","level":10,"bulb_mode":"white","effect":"white_mode"}

$ curl milight-hub/gateways/0x2200/rgb_cct/1
{"status":"ON","level":10,"kelvin":10,"bulb_mode":"white","effect":"white_mode"}

$ curl milight-hub/gateways/0x2200/rgb_cct/2
{"status":"ON","level":10,"kelvin":100,"bulb_mode":"white","effect":"white_mode"}
```