### PR TITLE
Fix scratch state regression

### DIFF
--- a/lib/MiLightState/GroupState.cpp
+++ b/lib/MiLightState/GroupState.cpp
@@ -121,13 +121,13 @@ GroupState::GroupState(const GroupState& other)
   scratchpad.rawData = other.scratchpad.rawData;
 }
 
-GroupState::GroupState(const GroupState* other, const JsonObject& jsonState) 
-  : previousState(other)
+GroupState::GroupState(const GroupState* previousState, const JsonObject& jsonState)
+  : previousState(previousState)
 {
   initFields();
 
-  if (other != NULL) {
-    this->scratchpad = other->scratchpad;
+  if (previousState != NULL) {
+    this->scratchpad = previousState->scratchpad;
   }
 
   patch(jsonState);

--- a/lib/MiLightState/GroupState.cpp
+++ b/lib/MiLightState/GroupState.cpp
@@ -14,6 +14,11 @@ static const GroupStateField ALL_PHYSICAL_FIELDS[] = {
   GroupStateField::STATE
 };
 
+static const GroupStateField ALL_SCRATCH_FIELDS[] = {
+  GroupStateField::BRIGHTNESS,
+  GroupStateField::KELVIN
+};
+
 // Number of units each increment command counts for
 static const uint8_t INCREMENT_COMMAND_VALUE = 10;
 
@@ -68,15 +73,6 @@ bool BulbId::operator==(const BulbId &other) {
     && deviceType == other.deviceType;
 }
 
-GroupState::GroupState() {
-  initFields();
-}
-
-GroupState::GroupState(const JsonObject& jsonState) {
-  initFields();
-  patch(jsonState);
-}
-
 void GroupState::initFields() {
   state.fields._state                = 0;
   state.fields._brightness           = 0;
@@ -112,9 +108,29 @@ GroupState& GroupState::operator=(const GroupState& other) {
   scratchpad.rawData = other.scratchpad.rawData;
 }
 
-GroupState::GroupState(const GroupState& other) {
+GroupState::GroupState() 
+  : previousState(NULL)
+{
+  initFields();
+}
+
+GroupState::GroupState(const GroupState& other) 
+  : previousState(NULL)
+{
   memcpy(state.rawData, other.state.rawData, DATA_LONGS * sizeof(uint32_t));
   scratchpad.rawData = other.scratchpad.rawData;
+}
+
+GroupState::GroupState(const GroupState* other, const JsonObject& jsonState) 
+  : previousState(other)
+{
+  initFields();
+
+  if (other != NULL) {
+    this->scratchpad = other->scratchpad;
+  }
+
+  patch(jsonState);
 }
 
 bool GroupState::operator==(const GroupState& other) const {
@@ -591,16 +607,17 @@ bool GroupState::applyIncrementCommand(GroupStateField field, IncrementDirection
   int8_t dirValue = static_cast<int8_t>(dir);
 
   // If there's already a known value, update it
-  if (isSetField(field)) {
-    int8_t currentValue = static_cast<int8_t>(getFieldValue(field));
+  if (previousState != NULL && previousState->isSetField(field)) {
+    int8_t currentValue = static_cast<int8_t>(previousState->getFieldValue(field));
     int8_t newValue = currentValue + (dirValue * INCREMENT_COMMAND_VALUE);
 
 #ifdef STATE_DEBUG
-    debugState("Updating field from increment command");
+    previousState->debugState("Updating field from increment command");
 #endif
 
     // For now, assume range for both brightness and kelvin is [0, 100]
     setFieldValue(field, constrain(newValue, 0, 100));
+
     return true;
   // Otherwise start or update scratch state
   } else {
@@ -668,6 +685,14 @@ bool GroupState::patch(const GroupState& other) {
       setFieldValue(field, other.getFieldValue(field));
     }
   }
+
+  for (size_t i = 0; i < size(ALL_SCRATCH_FIELDS); ++i) {
+    GroupStateField field = ALL_SCRATCH_FIELDS[i];
+
+    if (other.isSetScratchField(field)) {
+      setScratchFieldValue(field, other.getScratchFieldValue(field));
+    }
+  }
 }
 
 /*
@@ -728,8 +753,10 @@ bool GroupState::patch(const JsonObject& state) {
       changes |= applyIncrementCommand(GroupStateField::BRIGHTNESS, IncrementDirection::DECREASE);
     } else if (isOn() && command == "temperature_up") {
       changes |= applyIncrementCommand(GroupStateField::KELVIN, IncrementDirection::INCREASE);
+      changes |= setBulbMode(BULB_MODE_WHITE);
     } else if (isOn() && command == "temperature_down") {
       changes |= applyIncrementCommand(GroupStateField::KELVIN, IncrementDirection::DECREASE);
+      changes |= setBulbMode(BULB_MODE_WHITE);
     }
   }
 

--- a/lib/MiLightState/GroupState.cpp
+++ b/lib/MiLightState/GroupState.cpp
@@ -108,13 +108,13 @@ GroupState& GroupState::operator=(const GroupState& other) {
   scratchpad.rawData = other.scratchpad.rawData;
 }
 
-GroupState::GroupState() 
+GroupState::GroupState()
   : previousState(NULL)
 {
   initFields();
 }
 
-GroupState::GroupState(const GroupState& other) 
+GroupState::GroupState(const GroupState& other)
   : previousState(NULL)
 {
   memcpy(state.rawData, other.state.rawData, DATA_LONGS * sizeof(uint32_t));

--- a/lib/MiLightState/GroupState.h
+++ b/lib/MiLightState/GroupState.h
@@ -51,7 +51,7 @@ public:
 
   // Convenience constructor that patches transient state from a previous GroupState,
   // and defaults with JSON state
-  GroupState(const GroupState* other, const JsonObject& jsonState);
+  GroupState(const GroupState* previousState, const JsonObject& jsonState);
 
   void initFields();
 

--- a/lib/MiLightState/GroupState.h
+++ b/lib/MiLightState/GroupState.h
@@ -49,8 +49,9 @@ public:
   GroupState(const GroupState& other);
   GroupState& operator=(const GroupState& other);
 
-  // Convenience constructor that patches defaults with JSON state
-  GroupState(const JsonObject& jsonState);
+  // Convenience constructor that patches transient state from a previous GroupState,
+  // and defaults with JSON state
+  GroupState(const GroupState* other, const JsonObject& jsonState);
 
   void initFields();
 
@@ -210,6 +211,12 @@ private:
 
   StateData state;
   TransientData scratchpad;
+
+  // State is constructed from individual command packets.  A command packet is parsed in
+  // isolation, and the result is patched onto previous state.  There are a few cases where
+  // it's necessary to know some things from the previous state, so we keep a reference to
+  // it here.
+  const GroupState* previousState;
 
   void applyColor(JsonObject& state, uint8_t r, uint8_t g, uint8_t b) const;
   void applyColor(JsonObject& state) const;

--- a/lib/MiLightState/GroupStateStore.cpp
+++ b/lib/MiLightState/GroupStateStore.cpp
@@ -11,6 +11,9 @@ GroupState* GroupStateStore::get(const BulbId& id) {
   GroupState* state = cache.get(id);
 
   if (state == NULL) {
+#if STATE_DEBUG
+    Serial.println(F("Couldn't fetch state from cache, getting it from persistence"));
+#endif
     trackEviction();
     GroupState loadedState = GroupState::defaultState(id.deviceType);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -109,7 +109,9 @@ void onPacketSentHandler(uint8_t* packet, const MiLightRemoteConfig& config) {
 
   // update state to reflect changes from this packet
   GroupState* groupState = stateStore->get(bulbId);
-  const GroupState stateUpdates(result);
+
+  // pass in previous scratch state as well
+  const GroupState stateUpdates(groupState, result);
 
   if (groupState != NULL) {
     groupState->patch(stateUpdates);


### PR DESCRIPTION
A regression was introduced in the 1.9.0-dev12, breaking the increment/decrement state tracking added in a previous version.  This fixes the regression and adds a test.