### PR TITLE
Add support for :dec_device_id and :hex_device_id in command topic

### DIFF
--- a/lib/MQTT/MqttClient.cpp
+++ b/lib/MQTT/MqttClient.cpp
@@ -126,6 +126,8 @@ void MqttClient::subscribe() {
   String topic = settings.mqttTopicPattern;
 
   topic.replace(":device_id", "+");
+  topic.replace(":hex_device_id", "+");
+  topic.replace(":dec_device_id", "+");
   topic.replace(":group_id", "+");
   topic.replace(":device_type", "+");
 
@@ -179,6 +181,10 @@ void MqttClient::publishCallback(char* topic, byte* payload, int length) {
 
   if (tokenBindings.hasBinding("device_id")) {
     deviceId = parseInt<uint16_t>(tokenBindings.get("device_id"));
+  } else if (tokenBindings.hasBinding("hex_device_id")) {
+    deviceId = parseInt<uint16_t>(tokenBindings.get("hex_device_id"));
+  } else if (tokenBindings.hasBinding("dec_device_id")) {
+    deviceId = parseInt<uint16_t>(tokenBindings.get("dec_device_id"));
   }
 
   if (tokenBindings.hasBinding("group_id")) {

--- a/test/remote/lib/mqtt_client.rb
+++ b/test/remote/lib/mqtt_client.rb
@@ -27,7 +27,13 @@ class MqttClient
 
   def id_topic_suffix(params)
     if params
-      "#{sprintf '0x%04X', params[:id]}/#{params[:type]}/#{params[:group_id]}"
+      str_id = if params[:id_format] == 'decimal'
+        params[:id].to_s
+      else
+        sprintf '0x%04X', params[:id]
+      end
+
+      "#{str_id}/#{params[:type]}/#{params[:group_id]}"
     else
       "+/+/+"
     end

--- a/test/remote/spec/mqtt_spec.rb
+++ b/test/remote/spec/mqtt_spec.rb
@@ -258,10 +258,104 @@ RSpec.describe 'State' do
       end
 
       # Will use hex by default
-      @mqtt_client.patch_state(@id_params, status: 'ON', level: 100)
+      @mqtt_client.patch_state(@id_params, status: 'ON')
       @mqtt_client.wait_for_listeners
 
       expect(seen).to eq(true), "Should see update for hex param"
+    end
+  end
+
+  context ':hex_device_id for update/state topics' do
+    before(:all) do
+      @client.put(
+        '/settings',
+        mqtt_state_topic_pattern: "#{@topic_prefix}state/:hex_device_id/:device_type/:group_id",
+        mqtt_update_topic_pattern: "#{@topic_prefix}updates/:hex_device_id/:device_type/:group_id"
+      )
+    end
+
+    after(:all) do
+      @client.put(
+        '/settings',
+        mqtt_state_topic_pattern: "#{@topic_prefix}state/:device_id/:device_type/:group_id",
+        mqtt_update_topic_pattern: "#{@topic_prefix}updates/:device_id/:device_type/:group_id"
+      )
+    end
+
+    it 'should publish updates with hexadecimal device ID' do
+      seen_update = false
+
+      @mqtt_client.on_update(@id_params) do |id, message|
+        seen_update = (message['state'] == 'ON')
+      end
+
+      # Will use hex by default
+      @mqtt_client.patch_state(@id_params, status: 'ON')
+      @mqtt_client.wait_for_listeners
+
+      expect(seen_update).to eq(true)
+    end
+
+    it 'should publish state with hexadecimal device ID' do
+      seen_state = false
+
+      @mqtt_client.on_state(@id_params) do |id, message|
+        seen_state = (message['status'] == 'ON')
+      end
+
+      # Will use hex by default
+      @mqtt_client.patch_state(@id_params, status: 'ON')
+      @mqtt_client.wait_for_listeners
+
+      expect(seen_state).to eq(true)
+    end
+  end
+
+  context ':dec_device_id for update/state topics' do
+    before(:all) do
+      @client.put(
+        '/settings',
+        mqtt_state_topic_pattern: "#{@topic_prefix}state/:dec_device_id/:device_type/:group_id",
+        mqtt_update_topic_pattern: "#{@topic_prefix}updates/:dec_device_id/:device_type/:group_id"
+      )
+    end
+
+    after(:all) do
+      @client.put(
+        '/settings',
+        mqtt_state_topic_pattern: "#{@topic_prefix}state/:device_id/:device_type/:group_id",
+        mqtt_update_topic_pattern: "#{@topic_prefix}updates/:device_id/:device_type/:group_id"
+      )
+    end
+
+    it 'should publish updates with hexadecimal device ID' do
+      seen_update = false
+      @id_params = @id_params.merge(id_format: 'decimal')
+
+      @mqtt_client.on_update(@id_params) do |id, message|
+        seen_update = (message['state'] == 'ON')
+      end
+
+      # Will use hex by default
+      @mqtt_client.patch_state(@id_params, status: 'ON')
+      @mqtt_client.wait_for_listeners
+
+      expect(seen_update).to eq(true)
+    end
+
+    it 'should publish state with hexadecimal device ID' do
+      seen_state = false
+      @id_params = @id_params.merge(id_format: 'decimal')
+
+      @mqtt_client.on_state(@id_params) do |id, message|
+        seen_state = (message['status'] == 'ON')
+      end
+
+      # Will use hex by default
+      @mqtt_client.patch_state(@id_params, status: 'ON')
+      @mqtt_client.wait_for_listeners
+
+      expect(seen_state).to eq(true)
     end
   end
 end


### PR DESCRIPTION
Both of these tokens are supported for state/update topic patterns.  Since the `:device_id` token for the command pattern supports both hexadecimal and decimal IDs, support for `:dec_device_id` and `:hex_device_id` was not added.

This can cause more confusion than it's worth (see #427).  This adds support.