### PR TITLE
Fix night mode state handling for CCT and RGBW

### DIFF
--- a/lib/MiLight/CctPacketFormatter.cpp
+++ b/lib/MiLight/CctPacketFormatter.cpp
@@ -199,7 +199,10 @@ BulbId CctPacketFormatter::parsePacket(const uint8_t* packet, JsonObject result)
     REMOTE_TYPE_CCT
   );
 
-  if (onOffGroupId < 255) {
+  // Night mode
+  if (command & 0x10) {
+    result["command"] = "night_mode";
+  } else if (onOffGroupId < 255) {
     result["state"] = cctCommandToStatus(command) == ON ? "ON" : "OFF";
   } else if (command == CCT_BRIGHTNESS_DOWN) {
     result["command"] = "brightness_down";

--- a/lib/MiLight/RgbwPacketFormatter.cpp
+++ b/lib/MiLight/RgbwPacketFormatter.cpp
@@ -96,7 +96,15 @@ void RgbwPacketFormatter::updateColorWhite() {
 void RgbwPacketFormatter::enableNightMode() {
   uint8_t button = STATUS_COMMAND(OFF, groupId);
 
-  command(button, 0);
+  // Bulbs must be OFF for night mode to work in RGBW.
+  // Turn it off if it isn't already off.
+  const GroupState* state = stateStore->get(deviceId, groupId, REMOTE_TYPE_RGBW);
+  if (state == NULL || state->getState() == MiLightStatus::ON) {
+    command(button, 0);
+  }
+
+  // Night mode command has 0x10 bit set, but is otherwise
+  // a repeat of the OFF command.
   command(button | 0x10, 0);
 }
 

--- a/lib/MiLight/RgbwPacketFormatter.cpp
+++ b/lib/MiLight/RgbwPacketFormatter.cpp
@@ -124,9 +124,8 @@ BulbId RgbwPacketFormatter::parsePacket(const uint8_t* packet, JsonObject result
     // the last packet sent, not the current one, and that can be wrong for
     // on/off commands.
     bulbId.groupId = GROUP_FOR_STATUS_COMMAND(command);
-  } else if (command >= RGBW_ALL_MAX_LEVEL && command <= RGBW_GROUP_4_MIN_LEVEL) {
+  } else if (command & 0x10) {
     if ((command % 2) == 0) {
-      result["state"] = "ON";
       result["command"] = "night_mode";
     } else {
       result["command"] = "set_white";

--- a/lib/MiLightState/GroupState.cpp
+++ b/lib/MiLightState/GroupState.cpp
@@ -709,10 +709,15 @@ void GroupState::patch(const GroupState& other) {
   for (size_t i = 0; i < size(ALL_PHYSICAL_FIELDS); ++i) {
     GroupStateField field = ALL_PHYSICAL_FIELDS[i];
 
+    // Handle night mode separately.  Should always set this field.
+    if (field == GroupStateField::BULB_MODE && other.isNightMode()) {
+      setFieldValue(field, other.getFieldValue(field));
+    }
+    // Otherwise...
     // Conditions:
     //   * Only set anything if field is set in other state
     //   * Do not patch anything other than STATE if bulb is off
-    if (other.isSetField(field) && (field == GroupStateField::STATE || isOn())) {
+    else if (other.isSetField(field) && (field == GroupStateField::STATE || isOn())) {
       setFieldValue(field, other.getFieldValue(field));
     }
   }

--- a/test/remote/helpers/state_helpers.rb
+++ b/test/remote/helpers/state_helpers.rb
@@ -1,4 +1,5 @@
 module StateHelpers
+  ALL_REMOTE_TYPES = %w(rgb rgbw rgb_cct cct fut089 fut091)
   def states_are_equal(desired_state, retrieved_state)
     expect(retrieved_state).to include(*desired_state.keys)
     expect(retrieved_state.select { |x| desired_state.include?(x) } ).to eq(desired_state)


### PR DESCRIPTION
* Fix packet parsing for RGBW and CCT handlers to properly recognize night_mode packets
* Fix state patching for night_mode
* Add night_mode tests for all bulb types (save for RGB, which doesn't support it)