### PR TITLE
New feature: transitions

### DIFF
--- a/lib/DataStructures/LinkedList.h
+++ b/lib/DataStructures/LinkedList.h
@@ -194,6 +194,7 @@ bool LinkedList<T>::add(T _t){
   if(root){
     // Already have elements inserted
     last->next = tmp;
+    tmp->prev = last;
     last = tmp;
   }else{
     // First element being inserted

--- a/lib/DataStructures/LinkedList.h
+++ b/lib/DataStructures/LinkedList.h
@@ -67,6 +67,7 @@ public:
     else, decrement _size
   */
   virtual T remove(int index);
+  virtual void remove(ListNode<T>* node);
   /*
     Remove last object;
   */
@@ -274,6 +275,24 @@ T LinkedList<T>::shift(){
     return pop();
   }
 
+}
+
+template<typename T>
+void LinkedList<T>::remove(ListNode<T>* node){
+  if (node == root) {
+    shift();
+  } else if (node == last) {
+    pop();
+  } else {
+    ListNode<T>* prev = node->prev;
+    ListNode<T>* next = node->next;
+
+    prev->next = next;
+    next->prev = prev;
+
+    delete node;
+    --_size;
+  }
 }
 
 template<typename T>

--- a/lib/MQTT/HomeAssistantDiscoveryClient.cpp
+++ b/lib/MQTT/HomeAssistantDiscoveryClient.cpp
@@ -1,4 +1,5 @@
 #include <HomeAssistantDiscoveryClient.h>
+#include <MiLightCommands.h>
 
 HomeAssistantDiscoveryClient::HomeAssistantDiscoveryClient(Settings& settings, MqttClient* mqttClient)
   : settings(settings)
@@ -54,7 +55,7 @@ void HomeAssistantDiscoveryClient::addConfig(const char* alias, const BulbId& bu
   config[GroupStateFieldNames::EFFECT] = true;
 
   JsonArray effects = config.createNestedArray(F("effect_list"));
-  effects.add(F("night_mode"));
+  effects.add(MiLightCommandNames::NIGHT_MODE);
 
   // These bulbs support RGB color
   switch (bulbId.deviceType) {

--- a/lib/MQTT/HomeAssistantDiscoveryClient.cpp
+++ b/lib/MQTT/HomeAssistantDiscoveryClient.cpp
@@ -50,8 +50,8 @@ void HomeAssistantDiscoveryClient::addConfig(const char* alias, const BulbId& bu
   // Configure supported commands based on the bulb type
 
   // All supported bulbs support brightness and night mode
-  config[F("brightness")] = true;
-  config[F("effect")] = true;
+  config[GroupStateFieldNames::BRIGHTNESS] = true;
+  config[GroupStateFieldNames::EFFECT] = true;
 
   JsonArray effects = config.createNestedArray(F("effect_list"));
   effects.add(F("night_mode"));
@@ -74,7 +74,7 @@ void HomeAssistantDiscoveryClient::addConfig(const char* alias, const BulbId& bu
     case REMOTE_TYPE_FUT089:
     case REMOTE_TYPE_FUT091:
     case REMOTE_TYPE_RGB_CCT:
-      config[F("color_temp")] = true;
+      config[GroupStateFieldNames::COLOR_TEMP] = true;
       break;
     default:
       break; //nothing
@@ -85,7 +85,7 @@ void HomeAssistantDiscoveryClient::addConfig(const char* alias, const BulbId& bu
     case REMOTE_TYPE_FUT089:
     case REMOTE_TYPE_RGB_CCT:
     case REMOTE_TYPE_RGBW:
-      effects.add(F("white_mode"));
+      effects.add("white_mode");
       break;
     default:
       break; //nothing

--- a/lib/MQTT/MqttClient.cpp
+++ b/lib/MQTT/MqttClient.cpp
@@ -238,20 +238,20 @@ void MqttClient::publishCallback(char* topic, byte* payload, int length) {
       groupId = bulbId.groupId;
     }
   } else {
-    if (tokenBindings.hasBinding("device_id")) {
-      deviceId = parseInt<uint16_t>(tokenBindings.get("device_id"));
+    if (tokenBindings.hasBinding(GroupStateFieldNames::DEVICE_ID)) {
+      deviceId = parseInt<uint16_t>(tokenBindings.get(GroupStateFieldNames::DEVICE_ID));
     } else if (tokenBindings.hasBinding("hex_device_id")) {
       deviceId = parseInt<uint16_t>(tokenBindings.get("hex_device_id"));
     } else if (tokenBindings.hasBinding("dec_device_id")) {
       deviceId = parseInt<uint16_t>(tokenBindings.get("dec_device_id"));
     }
 
-    if (tokenBindings.hasBinding("group_id")) {
-      groupId = parseInt<uint16_t>(tokenBindings.get("group_id"));
+    if (tokenBindings.hasBinding(GroupStateFieldNames::GROUP_ID)) {
+      groupId = parseInt<uint16_t>(tokenBindings.get(GroupStateFieldNames::GROUP_ID));
     }
 
-    if (tokenBindings.hasBinding("device_type")) {
-      config = MiLightRemoteConfig::fromType(tokenBindings.get("device_type"));
+    if (tokenBindings.hasBinding(GroupStateFieldNames::DEVICE_TYPE)) {
+      config = MiLightRemoteConfig::fromType(tokenBindings.get(GroupStateFieldNames::DEVICE_TYPE));
     } else {
       Serial.println(F("MqttClient - WARNING: could not find device_type token.  Defaulting to FUT092.\n"));
     }
@@ -304,7 +304,7 @@ String MqttClient::generateConnectionStatusMessage(const char* connectionStatus)
     }
   } else {
     StaticJsonDocument<1024> json;
-    json["status"] = connectionStatus;
+    json[GroupStateFieldNames::STATUS] = connectionStatus;
 
     // Fill other fields
     AboutHelper::generateAboutObject(json, true);

--- a/lib/MiLight/CctPacketFormatter.cpp
+++ b/lib/MiLight/CctPacketFormatter.cpp
@@ -203,7 +203,7 @@ BulbId CctPacketFormatter::parsePacket(const uint8_t* packet, JsonObject result)
   if (command & 0x10) {
     result["command"] = "night_mode";
   } else if (onOffGroupId < 255) {
-    result["state"] = cctCommandToStatus(command) == ON ? "ON" : "OFF";
+    result[GroupStateFieldNames::STATE] = cctCommandToStatus(command) == ON ? "ON" : "OFF";
   } else if (command == CCT_BRIGHTNESS_DOWN) {
     result["command"] = "brightness_down";
   } else if (command == CCT_BRIGHTNESS_UP) {

--- a/lib/MiLight/CctPacketFormatter.cpp
+++ b/lib/MiLight/CctPacketFormatter.cpp
@@ -202,17 +202,17 @@ BulbId CctPacketFormatter::parsePacket(const uint8_t* packet, JsonObject result)
 
   // Night mode
   if (command & 0x10) {
-    result["command"] = MiLightCommandNames::NIGHT_MODE;
+    result[GroupStateFieldNames::COMMAND] = MiLightCommandNames::NIGHT_MODE;
   } else if (onOffGroupId < 255) {
     result[GroupStateFieldNames::STATE] = cctCommandToStatus(command) == ON ? "ON" : "OFF";
   } else if (command == CCT_BRIGHTNESS_DOWN) {
-    result["command"] = "brightness_down";
+    result[GroupStateFieldNames::COMMAND] = "brightness_down";
   } else if (command == CCT_BRIGHTNESS_UP) {
-    result["command"] = "brightness_up";
+    result[GroupStateFieldNames::COMMAND] = "brightness_up";
   } else if (command == CCT_TEMPERATURE_DOWN) {
-    result["command"] = MiLightCommandNames::TEMPERATURE_DOWN;
+    result[GroupStateFieldNames::COMMAND] = MiLightCommandNames::TEMPERATURE_DOWN;
   } else if (command == CCT_TEMPERATURE_UP) {
-    result["command"] = MiLightCommandNames::TEMPERATURE_UP;
+    result[GroupStateFieldNames::COMMAND] = MiLightCommandNames::TEMPERATURE_UP;
   } else {
     result["button_id"] = command;
   }

--- a/lib/MiLight/CctPacketFormatter.cpp
+++ b/lib/MiLight/CctPacketFormatter.cpp
@@ -1,4 +1,5 @@
 #include <CctPacketFormatter.h>
+#include <MiLightCommands.h>
 
 static const uint8_t CCT_PROTOCOL_ID = 0x5A;
 
@@ -201,7 +202,7 @@ BulbId CctPacketFormatter::parsePacket(const uint8_t* packet, JsonObject result)
 
   // Night mode
   if (command & 0x10) {
-    result["command"] = "night_mode";
+    result["command"] = MiLightCommandNames::NIGHT_MODE;
   } else if (onOffGroupId < 255) {
     result[GroupStateFieldNames::STATE] = cctCommandToStatus(command) == ON ? "ON" : "OFF";
   } else if (command == CCT_BRIGHTNESS_DOWN) {
@@ -209,9 +210,9 @@ BulbId CctPacketFormatter::parsePacket(const uint8_t* packet, JsonObject result)
   } else if (command == CCT_BRIGHTNESS_UP) {
     result["command"] = "brightness_up";
   } else if (command == CCT_TEMPERATURE_DOWN) {
-    result["command"] = "temperature_down";
+    result["command"] = MiLightCommandNames::TEMPERATURE_DOWN;
   } else if (command == CCT_TEMPERATURE_UP) {
-    result["command"] = "temperature_up";
+    result["command"] = MiLightCommandNames::TEMPERATURE_UP;
   } else {
     result["button_id"] = command;
   }

--- a/lib/MiLight/FUT089PacketFormatter.cpp
+++ b/lib/MiLight/FUT089PacketFormatter.cpp
@@ -114,13 +114,13 @@ BulbId FUT089PacketFormatter::parsePacket(const uint8_t *packet, JsonObject resu
 
   if (command == FUT089_ON) {
     if ((packetCopy[V2_COMMAND_INDEX] & 0x80) == 0x80) {
-      result["command"] = MiLightCommandNames::NIGHT_MODE;
+      result[GroupStateFieldNames::COMMAND] = MiLightCommandNames::NIGHT_MODE;
     } else if (arg == FUT089_MODE_SPEED_DOWN) {
-      result["command"] = MiLightCommandNames::MODE_SPEED_DOWN;
+      result[GroupStateFieldNames::COMMAND] = MiLightCommandNames::MODE_SPEED_DOWN;
     } else if (arg == FUT089_MODE_SPEED_UP) {
-      result["command"] = MiLightCommandNames::MODE_SPEED_UP;
+      result[GroupStateFieldNames::COMMAND] = MiLightCommandNames::MODE_SPEED_UP;
     } else if (arg == FUT089_WHITE_MODE) {
-      result["command"] = MiLightCommandNames::SET_WHITE;
+      result[GroupStateFieldNames::COMMAND] = MiLightCommandNames::SET_WHITE;
     } else if (arg <= 8) { // Group is not reliably encoded in group byte. Extract from arg byte
       result[GroupStateFieldNames::STATE] = "ON";
       bulbId.groupId = arg;

--- a/lib/MiLight/FUT089PacketFormatter.cpp
+++ b/lib/MiLight/FUT089PacketFormatter.cpp
@@ -121,31 +121,31 @@ BulbId FUT089PacketFormatter::parsePacket(const uint8_t *packet, JsonObject resu
     } else if (arg == FUT089_WHITE_MODE) {
       result["command"] = "set_white";
     } else if (arg <= 8) { // Group is not reliably encoded in group byte. Extract from arg byte
-      result["state"] = "ON";
+      result[GroupStateFieldNames::STATE] = "ON";
       bulbId.groupId = arg;
     } else if (arg >= 9 && arg <= 17) {
-      result["state"] = "OFF";
+      result[GroupStateFieldNames::STATE] = "OFF";
       bulbId.groupId = arg-9;
     }
   } else if (command == FUT089_COLOR) {
     uint8_t rescaledColor = (arg - FUT089_COLOR_OFFSET) % 0x100;
     uint16_t hue = Units::rescale<uint16_t, uint16_t>(rescaledColor, 360, 255.0);
-    result["hue"] = hue;
+    result[GroupStateFieldNames::HUE] = hue;
   } else if (command == FUT089_BRIGHTNESS) {
     uint8_t level = constrain(arg, 0, 100);
-    result["brightness"] = Units::rescale<uint8_t, uint8_t>(level, 255, 100);
+    result[GroupStateFieldNames::BRIGHTNESS] = Units::rescale<uint8_t, uint8_t>(level, 255, 100);
   // saturation == kelvin. arg ranges are the same, so can't distinguish
   // without using state
   } else if (command == FUT089_SATURATION) {
     const GroupState* state = stateStore->get(bulbId);
 
     if (state != NULL && state->getBulbMode() == BULB_MODE_COLOR) {
-      result["saturation"] = 100 - constrain(arg, 0, 100);
+      result[GroupStateFieldNames::SATURATION] = 100 - constrain(arg, 0, 100);
     } else {
-      result["color_temp"] = Units::whiteValToMireds(100 - arg, 100);
+      result[GroupStateFieldNames::COLOR_TEMP] = Units::whiteValToMireds(100 - arg, 100);
     }
   } else if (command == FUT089_MODE) {
-    result["mode"] = arg;
+    result[GroupStateFieldNames::MODE] = arg;
   } else {
     result["button_id"] = command;
     result["argument"] = arg;

--- a/lib/MiLight/FUT089PacketFormatter.cpp
+++ b/lib/MiLight/FUT089PacketFormatter.cpp
@@ -1,6 +1,7 @@
 #include <FUT089PacketFormatter.h>
 #include <V2RFEncoding.h>
 #include <Units.h>
+#include <MiLightCommands.h>
 
 void FUT089PacketFormatter::modeSpeedDown() {
   command(FUT089_ON, FUT089_MODE_SPEED_DOWN);
@@ -113,13 +114,13 @@ BulbId FUT089PacketFormatter::parsePacket(const uint8_t *packet, JsonObject resu
 
   if (command == FUT089_ON) {
     if ((packetCopy[V2_COMMAND_INDEX] & 0x80) == 0x80) {
-      result["command"] = "night_mode";
+      result["command"] = MiLightCommandNames::NIGHT_MODE;
     } else if (arg == FUT089_MODE_SPEED_DOWN) {
-      result["command"] = "mode_speed_down";
+      result["command"] = MiLightCommandNames::MODE_SPEED_DOWN;
     } else if (arg == FUT089_MODE_SPEED_UP) {
-      result["command"] = "mode_speed_up";
+      result["command"] = MiLightCommandNames::MODE_SPEED_UP;
     } else if (arg == FUT089_WHITE_MODE) {
-      result["command"] = "set_white";
+      result["command"] = MiLightCommandNames::SET_WHITE;
     } else if (arg <= 8) { // Group is not reliably encoded in group byte. Extract from arg byte
       result[GroupStateFieldNames::STATE] = "ON";
       bulbId.groupId = arg;

--- a/lib/MiLight/FUT091PacketFormatter.cpp
+++ b/lib/MiLight/FUT091PacketFormatter.cpp
@@ -1,6 +1,7 @@
 #include <FUT091PacketFormatter.h>
 #include <V2RFEncoding.h>
 #include <Units.h>
+#include <MiLightCommands.h>
 
 static const uint8_t BRIGHTNESS_SCALE_MAX = 0x97;
 static const uint8_t KELVIN_SCALE_MAX = 0xC5;
@@ -34,7 +35,7 @@ BulbId FUT091PacketFormatter::parsePacket(const uint8_t *packet, JsonObject resu
 
   if (command == (uint8_t)FUT091Command::ON_OFF) {
     if ((packetCopy[V2_COMMAND_INDEX] & 0x80) == 0x80) {
-      result["command"] = "night_mode";
+      result["command"] = MiLightCommandNames::NIGHT_MODE;
     } else if (arg < 5) { // Group is not reliably encoded in group byte. Extract from arg byte
       result[GroupStateFieldNames::STATE] = "ON";
       bulbId.groupId = arg;

--- a/lib/MiLight/FUT091PacketFormatter.cpp
+++ b/lib/MiLight/FUT091PacketFormatter.cpp
@@ -35,7 +35,7 @@ BulbId FUT091PacketFormatter::parsePacket(const uint8_t *packet, JsonObject resu
 
   if (command == (uint8_t)FUT091Command::ON_OFF) {
     if ((packetCopy[V2_COMMAND_INDEX] & 0x80) == 0x80) {
-      result["command"] = MiLightCommandNames::NIGHT_MODE;
+      result[GroupStateFieldNames::COMMAND] = MiLightCommandNames::NIGHT_MODE;
     } else if (arg < 5) { // Group is not reliably encoded in group byte. Extract from arg byte
       result[GroupStateFieldNames::STATE] = "ON";
       bulbId.groupId = arg;

--- a/lib/MiLight/FUT091PacketFormatter.cpp
+++ b/lib/MiLight/FUT091PacketFormatter.cpp
@@ -36,18 +36,18 @@ BulbId FUT091PacketFormatter::parsePacket(const uint8_t *packet, JsonObject resu
     if ((packetCopy[V2_COMMAND_INDEX] & 0x80) == 0x80) {
       result["command"] = "night_mode";
     } else if (arg < 5) { // Group is not reliably encoded in group byte. Extract from arg byte
-      result["state"] = "ON";
+      result[GroupStateFieldNames::STATE] = "ON";
       bulbId.groupId = arg;
     } else {
-      result["state"] = "OFF";
+      result[GroupStateFieldNames::STATE] = "OFF";
       bulbId.groupId = arg-5;
     }
   } else if (command == (uint8_t)FUT091Command::BRIGHTNESS) {
     uint8_t level = V2PacketFormatter::fromv2scale(arg, BRIGHTNESS_SCALE_MAX, 2, true);
-    result["brightness"] = Units::rescale<uint8_t, uint8_t>(level, 255, 100);
+    result[GroupStateFieldNames::BRIGHTNESS] = Units::rescale<uint8_t, uint8_t>(level, 255, 100);
   } else if (command == (uint8_t)FUT091Command::KELVIN) {
     uint8_t kelvin = V2PacketFormatter::fromv2scale(arg, KELVIN_SCALE_MAX, 2, false);
-    result["color_temp"] = Units::whiteValToMireds(kelvin, 100);
+    result[GroupStateFieldNames::COLOR_TEMP] = Units::whiteValToMireds(kelvin, 100);
   } else {
     result["button_id"] = command;
     result["argument"] = arg;

--- a/lib/MiLight/MiLightClient.cpp
+++ b/lib/MiLight/MiLightClient.cpp
@@ -10,7 +10,7 @@
 
 using namespace std::placeholders;
 
-const std::map<const char*, std::function<void(MiLightClient*, JsonVariant)>> MiLightClient::FIELD_SETTERS = {
+const std::map<const char*, std::function<void(MiLightClient*, JsonVariant)>, MiLightClient::cmp_str> MiLightClient::FIELD_SETTERS = {
   {GroupStateFieldNames::LEVEL, &MiLightClient::updateBrightness},
   {
     GroupStateFieldNames::BRIGHTNESS,

--- a/lib/MiLight/MiLightClient.cpp
+++ b/lib/MiLight/MiLightClient.cpp
@@ -282,12 +282,12 @@ void MiLightClient::update(JsonObject request) {
     this->updateStatus(ON);
   }
 
-  if (request.containsKey("command")) {
-    this->handleCommand(request["command"]);
+  if (request.containsKey(GroupStateFieldNames::COMMAND)) {
+    this->handleCommand(request[GroupStateFieldNames::COMMAND]);
   }
 
-  if (request.containsKey("commands")) {
-    JsonArray commands = request["commands"];
+  if (request.containsKey(GroupStateFieldNames::COMMANDS)) {
+    JsonArray commands = request[GroupStateFieldNames::COMMANDS];
 
     if (! commands.isNull()) {
       for (size_t i = 0; i < commands.size(); i++) {
@@ -368,7 +368,7 @@ void MiLightClient::handleCommand(JsonVariant command) {
 
   if (command.is<JsonObject>()) {
     JsonObject cmdObj = command.as<JsonObject>();
-    cmdName = cmdObj["command"].as<const char*>();
+    cmdName = cmdObj[GroupStateFieldNames::COMMAND].as<const char*>();
     args = cmdObj["args"];
   } else if (command.is<const char*>()) {
     cmdName = command.as<const char*>();

--- a/lib/MiLight/MiLightClient.cpp
+++ b/lib/MiLight/MiLightClient.cpp
@@ -248,20 +248,20 @@ void MiLightClient::update(JsonObject request) {
   }
 
   //Homeassistant - Handle effect
-  if (request.containsKey("effect")) {
-    this->handleEffect(request["effect"]);
+  if (request.containsKey(GroupStateFieldNames::EFFECT)) {
+    this->handleEffect(request[GroupStateFieldNames::EFFECT]);
   }
 
-  if (request.containsKey("hue")) {
-    this->updateHue(request["hue"]);
+  if (request.containsKey(GroupStateFieldNames::HUE)) {
+    this->updateHue(request[GroupStateFieldNames::HUE]);
   }
-  if (request.containsKey("saturation")) {
-    this->updateSaturation(request["saturation"]);
+  if (request.containsKey(GroupStateFieldNames::SATURATION)) {
+    this->updateSaturation(request[GroupStateFieldNames::SATURATION]);
   }
 
   // Convert RGB to HSV
-  if (request.containsKey("color")) {
-    ParsedColor color = ParsedColor::fromJson(request["color"]);
+  if (request.containsKey(GroupStateFieldNames::COLOR)) {
+    ParsedColor color = ParsedColor::fromJson(request[GroupStateFieldNames::COLOR]);
 
     if (!color.success) {
       Serial.println(F("Error parsing JSON color"));
@@ -280,30 +280,30 @@ void MiLightClient::update(JsonObject request) {
     }
   }
 
-  if (request.containsKey("level")) {
-    this->updateBrightness(request["level"]);
+  if (request.containsKey(GroupStateFieldNames::LEVEL)) {
+    this->updateBrightness(request[GroupStateFieldNames::LEVEL]);
   }
   // HomeAssistant
-  if (request.containsKey("brightness")) {
-    uint8_t scaledBrightness = Units::rescale(request["brightness"].as<uint8_t>(), 100, 255);
+  if (request.containsKey(GroupStateFieldNames::BRIGHTNESS)) {
+    uint8_t scaledBrightness = Units::rescale(request[GroupStateFieldNames::BRIGHTNESS].as<uint8_t>(), 100, 255);
     this->updateBrightness(scaledBrightness);
   }
 
   if (request.containsKey("temperature")) {
     this->updateTemperature(request["temperature"]);
   }
-  if (request.containsKey("kelvin")) {
-    this->updateTemperature(request["kelvin"]);
+  if (request.containsKey(GroupStateFieldNames::KELVIN)) {
+    this->updateTemperature(request[GroupStateFieldNames::KELVIN]);
   }
   // HomeAssistant
-  if (request.containsKey("color_temp")) {
+  if (request.containsKey(GroupStateFieldNames::COLOR_TEMP)) {
     this->updateTemperature(
-      Units::miredsToWhiteVal(request["color_temp"], 100)
+      Units::miredsToWhiteVal(request[GroupStateFieldNames::COLOR_TEMP], 100)
     );
   }
 
-  if (request.containsKey("mode")) {
-    this->updateMode(request["mode"]);
+  if (request.containsKey(GroupStateFieldNames::MODE)) {
+    this->updateMode(request[GroupStateFieldNames::MODE]);
   }
 
   // Raw packet command/args
@@ -450,10 +450,10 @@ void MiLightClient::handleEffect(const String& effect) {
 uint8_t MiLightClient::parseStatus(JsonObject object) {
   JsonVariant status;
 
-  if (object.containsKey("status")) {
-    status = object["status"];
-  } else if (object.containsKey("state")) {
-    status = object["state"];
+  if (object.containsKey(GroupStateFieldNames::STATUS)) {
+    status = object[GroupStateFieldNames::STATUS];
+  } else if (object.containsKey(GroupStateFieldNames::STATE)) {
+    status = object[GroupStateFieldNames::STATE];
   } else {
     return 255;
   }

--- a/lib/MiLight/MiLightClient.cpp
+++ b/lib/MiLight/MiLightClient.cpp
@@ -276,6 +276,18 @@ void MiLightClient::update(JsonObject request) {
   }
 
   const uint8_t parsedStatus = this->parseStatus(request);
+  const JsonVariant jsonTransition = request[RequestKeys::TRANSITION];
+  float transition = 0;
+
+  if (!jsonTransition.isNull()) {
+    if (jsonTransition.is<float>()) {
+      transition = jsonTransition.as<float>();
+    } else if (jsonTransition.is<size_t>()) {
+      transition = jsonTransition.as<size_t>();
+    } else {
+      Serial.println(F("MiLightClient - WARN: unsupported transition type.  Must be float or int."));
+    }
+  }
 
   // Always turn on first
   if (parsedStatus == ON) {
@@ -287,11 +299,11 @@ void MiLightClient::update(JsonObject request) {
     auto handler = MiLightClient::FIELD_SETTERS.find(fieldName);
 
     if (handler != FIELD_SETTERS.end()) {
-      if (request.containsKey(RequestKeys::TRANSITION)) {
+      if (transition != 0) {
         handleTransition(
           GroupStateFieldHelpers::getFieldByName(fieldName),
           jsonKv.value(),
-          request[RequestKeys::TRANSITION].as<float>()
+          transition
         );
       } else { // set the field directly
         handler->second(this, jsonKv.value());

--- a/lib/MiLight/MiLightClient.cpp
+++ b/lib/MiLight/MiLightClient.cpp
@@ -240,7 +240,7 @@ void MiLightClient::update(JsonObject request) {
 
     if (! commands.isNull()) {
       for (size_t i = 0; i < commands.size(); i++) {
-        this->handleCommand(commands[i].as<const char*>());
+        this->handleCommand(commands[i]);
       }
     }
   }
@@ -319,32 +319,43 @@ void MiLightClient::update(JsonObject request) {
   }
 }
 
-void MiLightClient::handleCommand(const String& command) {
-  if (command == "unpair") {
+void MiLightClient::handleCommand(JsonVariant command) {
+  String cmdName;
+  JsonObject args;
+
+  if (command.is<JsonObject>()) {
+    JsonObject cmdObj = command.as<JsonObject>();
+    cmdName = cmdObj["command"].as<const char*>();
+    args = cmdObj["args"];
+  } else if (command.is<const char*>()) {
+    cmdName = command.as<const char*>();
+  }
+
+  if (cmdName == "unpair") {
     this->unpair();
-  } else if (command == "pair") {
+  } else if (cmdName == "pair") {
     this->pair();
-  } else if (command == "set_white") {
+  } else if (cmdName == "set_white") {
     this->updateColorWhite();
-  } else if (command == "night_mode") {
+  } else if (cmdName == "night_mode") {
     this->enableNightMode();
-  } else if (command == "level_up") {
+  } else if (cmdName == "level_up") {
     this->increaseBrightness();
-  } else if (command == "level_down") {
+  } else if (cmdName == "level_down") {
     this->decreaseBrightness();
-  } else if (command == "temperature_up") {
+  } else if (cmdName == "temperature_up") {
     this->increaseTemperature();
-  } else if (command == "temperature_down") {
+  } else if (cmdName == "temperature_down") {
     this->decreaseTemperature();
-  } else if (command == "next_mode") {
+  } else if (cmdName == "next_mode") {
     this->nextMode();
-  } else if (command == "previous_mode") {
+  } else if (cmdName == "previous_mode") {
     this->previousMode();
-  } else if (command == "mode_speed_down") {
+  } else if (cmdName == "mode_speed_down") {
     this->modeSpeedDown();
-  } else if (command == "mode_speed_up") {
+  } else if (cmdName == "mode_speed_up") {
     this->modeSpeedUp();
-  } else if (command == "toggle") {
+  } else if (cmdName == "toggle") {
     this->toggleStatus();
   }
 }

--- a/lib/MiLight/MiLightClient.cpp
+++ b/lib/MiLight/MiLightClient.cpp
@@ -34,7 +34,7 @@ const std::map<const char*, std::function<void(MiLightClient*, JsonVariant)>, Mi
   {
     GroupStateFieldNames::BRIGHTNESS,
     [](MiLightClient* client, uint16_t arg) {
-      client->updateBrightness(Units::rescale(arg, 255, 100));
+      client->updateBrightness(Units::rescale<uint16_t, uint16_t>(arg, 100, 255));
     }
   },
   {GroupStateFieldNames::HUE, &MiLightClient::updateHue},

--- a/lib/MiLight/MiLightClient.cpp
+++ b/lib/MiLight/MiLightClient.cpp
@@ -291,7 +291,7 @@ void MiLightClient::update(JsonObject request) {
         handleTransition(
           GroupStateFieldHelpers::getFieldByName(fieldName),
           jsonKv.value(),
-          request[RequestKeys::TRANSITION].as<size_t>() * TRANSITION_KEY_UNIT_MULTIPLIER
+          request[RequestKeys::TRANSITION].as<float>()
         );
       } else { // set the field directly
         handler->second(this, jsonKv.value());
@@ -365,7 +365,7 @@ void MiLightClient::handleCommand(JsonVariant command) {
   }
 }
 
-void MiLightClient::handleTransition(GroupStateField field, JsonVariant value, size_t duration) {
+void MiLightClient::handleTransition(GroupStateField field, JsonVariant value, float duration) {
   BulbId bulbId = currentRemote->packetFormatter->currentBulbId();
   GroupState* currentState = stateStore->get(bulbId);
   std::shared_ptr<Transition::Builder> transitionBuilder = nullptr;

--- a/lib/MiLight/MiLightClient.cpp
+++ b/lib/MiLight/MiLightClient.cpp
@@ -395,7 +395,14 @@ void MiLightClient::handleTransition(JsonObject args) {
     case GroupStateField::LEVEL:
     case GroupStateField::KELVIN:
     case GroupStateField::COLOR_TEMP:
-      transitions.scheduleTransition(field, args[F("start_value")], args[F("end_value")], stepSize, duration);
+      transitions.scheduleTransition(
+        currentRemote->packetFormatter->currentBulbId(),
+        field,
+        args[F("start_value")],
+        args[F("end_value")],
+        stepSize,
+        duration
+      );
       return;
 
     default:
@@ -416,7 +423,13 @@ void MiLightClient::handleTransition(JsonObject args) {
       return;
     }
 
-    transitions.scheduleTransition(startColor, endColor, stepSize, duration);
+    transitions.scheduleTransition(
+      currentRemote->packetFormatter->currentBulbId(),
+      startColor,
+      endColor,
+      stepSize,
+      duration
+    );
 
     return;
   }

--- a/lib/MiLight/MiLightClient.cpp
+++ b/lib/MiLight/MiLightClient.cpp
@@ -423,7 +423,7 @@ void MiLightClient::handleTransition(GroupStateField field, JsonVariant value, f
       endColor
     );
   } else {
-    uint16_t currentValue = currentState->getFieldValue(field);
+    uint16_t currentValue = currentState->getParsedFieldValue(field);
     uint16_t endValue = value;
 
     transitionBuilder = transitions.buildFieldTransition(

--- a/lib/MiLight/MiLightClient.cpp
+++ b/lib/MiLight/MiLightClient.cpp
@@ -5,6 +5,7 @@
 #include <Units.h>
 #include <TokenIterator.h>
 #include <ParsedColor.h>
+#include <MiLightCommands.h>
 #include <functional>
 
 using namespace std::placeholders;
@@ -373,33 +374,33 @@ void MiLightClient::handleCommand(JsonVariant command) {
     cmdName = command.as<const char*>();
   }
 
-  if (cmdName == "unpair") {
+  if (cmdName == MiLightCommandNames::UNPAIR) {
     this->unpair();
-  } else if (cmdName == "pair") {
+  } else if (cmdName == MiLightCommandNames::PAIR) {
     this->pair();
-  } else if (cmdName == "set_white") {
+  } else if (cmdName == MiLightCommandNames::SET_WHITE) {
     this->updateColorWhite();
-  } else if (cmdName == "night_mode") {
+  } else if (cmdName == MiLightCommandNames::NIGHT_MODE) {
     this->enableNightMode();
-  } else if (cmdName == "level_up") {
+  } else if (cmdName == MiLightCommandNames::LEVEL_UP) {
     this->increaseBrightness();
-  } else if (cmdName == "level_down") {
+  } else if (cmdName == MiLightCommandNames::LEVEL_DOWN) {
     this->decreaseBrightness();
-  } else if (cmdName == "temperature_up") {
+  } else if (cmdName == MiLightCommandNames::TEMPERATURE_UP) {
     this->increaseTemperature();
-  } else if (cmdName == "temperature_down") {
+  } else if (cmdName == MiLightCommandNames::TEMPERATURE_DOWN) {
     this->decreaseTemperature();
-  } else if (cmdName == "next_mode") {
+  } else if (cmdName == MiLightCommandNames::NEXT_MODE) {
     this->nextMode();
-  } else if (cmdName == "previous_mode") {
+  } else if (cmdName == MiLightCommandNames::PREVIOUS_MODE) {
     this->previousMode();
-  } else if (cmdName == "mode_speed_down") {
+  } else if (cmdName == MiLightCommandNames::MODE_SPEED_DOWN) {
     this->modeSpeedDown();
-  } else if (cmdName == "mode_speed_up") {
+  } else if (cmdName == MiLightCommandNames::MODE_SPEED_UP) {
     this->modeSpeedUp();
-  } else if (cmdName == "toggle") {
+  } else if (cmdName == MiLightCommandNames::TOGGLE) {
     this->toggleStatus();
-  } else if (cmdName == "transition") {
+  } else if (cmdName == MiLightCommandNames::TRANSITION) {
     this->handleTransition(args);
   }
 }
@@ -478,7 +479,7 @@ void MiLightClient::handleTransition(JsonObject args) {
 }
 
 void MiLightClient::handleEffect(const String& effect) {
-  if (effect == "night_mode") {
+  if (effect == MiLightCommandNames::NIGHT_MODE) {
     this->enableNightMode();
   } else if (effect == "white" || effect == "white_mode") {
     this->updateColorWhite();

--- a/lib/MiLight/MiLightClient.h
+++ b/lib/MiLight/MiLightClient.h
@@ -92,7 +92,7 @@ public:
   void update(JsonObject object);
   void handleCommand(JsonVariant command);
   void handleCommands(JsonArray commands);
-  void handleTransition(JsonObject args);
+  bool handleTransition(JsonObject args, JsonDocument& responseObj);
   void handleTransition(GroupStateField field, JsonVariant value, float duration);
   void handleEffect(const String& effect);
 

--- a/lib/MiLight/MiLightClient.h
+++ b/lib/MiLight/MiLightClient.h
@@ -69,7 +69,7 @@ public:
   void updateSaturation(const uint8_t saturation);
 
   void update(JsonObject object);
-  void handleCommand(const String& command);
+  void handleCommand(JsonVariant command);
   void handleEffect(const String& effect);
 
   void onUpdateBegin(EventHandler handler);

--- a/lib/MiLight/MiLightClient.h
+++ b/lib/MiLight/MiLightClient.h
@@ -34,9 +34,6 @@ namespace TransitionParams {
 
 class MiLightClient {
 public:
-  // transition commands are in seconds, convert to ms.
-  static const uint16_t TRANSITION_KEY_UNIT_MULTIPLIER = 1000;
-
   MiLightClient(
     RadioSwitchboard& radioSwitchboard,
     PacketSender& packetSender,
@@ -93,7 +90,7 @@ public:
   void handleCommand(JsonVariant command);
   void handleCommands(JsonArray commands);
   void handleTransition(JsonObject args);
-  void handleTransition(GroupStateField field, JsonVariant value, size_t duration);
+  void handleTransition(GroupStateField field, JsonVariant value, float duration);
   void handleEffect(const String& effect);
 
   void onUpdateBegin(EventHandler handler);

--- a/lib/MiLight/MiLightClient.h
+++ b/lib/MiLight/MiLightClient.h
@@ -60,6 +60,7 @@ public:
   void updateColorWhite();
   void updateColorRaw(const uint8_t color);
   void enableNightMode();
+  void updateColor(JsonVariant json);
 
   // CCT methods
   void updateTemperature(const uint8_t colorTemperature);
@@ -72,6 +73,7 @@ public:
 
   void update(JsonObject object);
   void handleCommand(JsonVariant command);
+  void handleCommands(JsonArray commands);
   void handleTransition(JsonObject args);
   void handleEffect(const String& effect);
 
@@ -89,7 +91,11 @@ public:
   // Clear the repeats override so that the default is used
   void clearRepeatsOverride();
 
+  uint8_t parseStatus(JsonObject object);
+
 protected:
+  static const std::map<const char*, std::function<void(MiLightClient*, JsonVariant)>> FIELD_SETTERS;
+
   RadioSwitchboard& radioSwitchboard;
   std::vector<std::shared_ptr<MiLightRadio>> radios;
   std::shared_ptr<MiLightRadio> currentRadio;
@@ -105,8 +111,6 @@ protected:
 
   // If set, override the number of packet repeats used.
   size_t repeatsOverride;
-
-  uint8_t parseStatus(JsonObject object);
 
   void flushPacket();
 };

--- a/lib/MiLight/MiLightClient.h
+++ b/lib/MiLight/MiLightClient.h
@@ -14,11 +14,29 @@
 //#define DEBUG_PRINTF
 //#define DEBUG_CLIENT_COMMANDS     // enable to show each individual change command (like hue, brightness, etc)
 
+#define FS(str) (reinterpret_cast<const __FlashStringHelper*>(str))
+
+namespace RequestKeys {
+  static const char TRANSITION[] = "transition";
+};
+
+namespace TransitionParams {
+  static const char FIELD[] PROGMEM = "field";
+  static const char START_VALUE[] PROGMEM = "start_value";
+  static const char END_VALUE[] PROGMEM = "end_value";
+  static const char DURATION[] PROGMEM = "duration";
+  static const char PERIOD[] PROGMEM = "period";
+  static const char NUM_PERIODS[] PROGMEM = "period";
+}
+
 // Used to determine RGB colros that are approximately white
 #define RGB_WHITE_THRESHOLD 10
 
 class MiLightClient {
 public:
+  // transition commands are in seconds, convert to ms.
+  static const uint16_t TRANSITION_KEY_UNIT_MULTIPLIER = 1000;
+
   MiLightClient(
     RadioSwitchboard& radioSwitchboard,
     PacketSender& packetSender,
@@ -75,6 +93,7 @@ public:
   void handleCommand(JsonVariant command);
   void handleCommands(JsonArray commands);
   void handleTransition(JsonObject args);
+  void handleTransition(GroupStateField field, JsonVariant value, size_t duration);
   void handleEffect(const String& effect);
 
   void onUpdateBegin(EventHandler handler);

--- a/lib/MiLight/MiLightClient.h
+++ b/lib/MiLight/MiLightClient.h
@@ -8,6 +8,8 @@
 #include <PacketSender.h>
 #include <TransitionController.h>
 #include <cstring>
+#include <map>
+#include <set>
 
 #ifndef _MILIGHTCLIENT_H
 #define _MILIGHTCLIENT_H
@@ -117,6 +119,7 @@ protected:
     }
   };
   static const std::map<const char*, std::function<void(MiLightClient*, JsonVariant)>, cmp_str> FIELD_SETTERS;
+  static const char* FIELD_ORDERINGS[];
 
   RadioSwitchboard& radioSwitchboard;
   std::vector<std::shared_ptr<MiLightRadio>> radios;

--- a/lib/MiLight/MiLightClient.h
+++ b/lib/MiLight/MiLightClient.h
@@ -7,6 +7,7 @@
 #include <GroupStateStore.h>
 #include <PacketSender.h>
 #include <TransitionController.h>
+#include <cstring>
 
 #ifndef _MILIGHTCLIENT_H
 #define _MILIGHTCLIENT_H
@@ -110,7 +111,12 @@ public:
   uint8_t parseStatus(JsonObject object);
 
 protected:
-  static const std::map<const char*, std::function<void(MiLightClient*, JsonVariant)>> FIELD_SETTERS;
+  struct cmp_str {
+    bool operator()(char const *a, char const *b) const {
+        return std::strcmp(a, b) < 0;
+    }
+  };
+  static const std::map<const char*, std::function<void(MiLightClient*, JsonVariant)>, cmp_str> FIELD_SETTERS;
 
   RadioSwitchboard& radioSwitchboard;
   std::vector<std::shared_ptr<MiLightRadio>> radios;

--- a/lib/MiLight/MiLightClient.h
+++ b/lib/MiLight/MiLightClient.h
@@ -29,7 +29,7 @@ namespace TransitionParams {
   static const char END_VALUE[] PROGMEM = "end_value";
   static const char DURATION[] PROGMEM = "duration";
   static const char PERIOD[] PROGMEM = "period";
-  static const char NUM_PERIODS[] PROGMEM = "period";
+  static const char NUM_PERIODS[] PROGMEM = "num_periods";
 }
 
 // Used to determine RGB colros that are approximately white

--- a/lib/MiLight/MiLightClient.h
+++ b/lib/MiLight/MiLightClient.h
@@ -6,6 +6,7 @@
 #include <Settings.h>
 #include <GroupStateStore.h>
 #include <PacketSender.h>
+#include <TransitionController.h>
 
 #ifndef _MILIGHTCLIENT_H
 #define _MILIGHTCLIENT_H
@@ -22,7 +23,8 @@ public:
     RadioSwitchboard& radioSwitchboard,
     PacketSender& packetSender,
     GroupStateStore* stateStore,
-    Settings& settings
+    Settings& settings,
+    TransitionController& transitions
   );
 
   ~MiLightClient() { }
@@ -70,6 +72,7 @@ public:
 
   void update(JsonObject object);
   void handleCommand(JsonVariant command);
+  void handleTransition(JsonObject args);
   void handleEffect(const String& effect);
 
   void onUpdateBegin(EventHandler handler);
@@ -98,6 +101,7 @@ protected:
   GroupStateStore* stateStore;
   Settings& settings;
   PacketSender& packetSender;
+  TransitionController& transitions;
 
   // If set, override the number of packet repeats used.
   size_t repeatsOverride;

--- a/lib/MiLight/PacketFormatter.cpp
+++ b/lib/MiLight/PacketFormatter.cpp
@@ -182,3 +182,7 @@ void PacketFormatter::formatV1Packet(uint8_t const* packet, char* buffer) {
 size_t PacketFormatter::getPacketLength() const {
   return packetLength;
 }
+
+BulbId PacketFormatter::currentBulbId() const {
+  return BulbId(deviceId, groupId, deviceType);
+}

--- a/lib/MiLight/PacketFormatter.h
+++ b/lib/MiLight/PacketFormatter.h
@@ -84,6 +84,7 @@ public:
   virtual void format(uint8_t const* packet, char* buffer);
 
   virtual BulbId parsePacket(const uint8_t* packet, JsonObject result);
+  virtual BulbId currentBulbId() const;
 
   static void formatV1Packet(uint8_t const* packet, char* buffer);
 

--- a/lib/MiLight/RgbCctPacketFormatter.cpp
+++ b/lib/MiLight/RgbCctPacketFormatter.cpp
@@ -128,27 +128,27 @@ BulbId RgbCctPacketFormatter::parsePacket(const uint8_t *packet, JsonObject resu
     } else if (arg == RGB_CCT_MODE_SPEED_UP) {
       result["command"] = "mode_speed_up";
     } else if (arg < 5) { // Group is not reliably encoded in group byte. Extract from arg byte
-      result["state"] = "ON";
+      result[GroupStateFieldNames::STATE] = "ON";
       bulbId.groupId = arg;
     } else {
-      result["state"] = "OFF";
+      result[GroupStateFieldNames::STATE] = "OFF";
       bulbId.groupId = arg-5;
     }
   } else if (command == RGB_CCT_COLOR) {
     uint8_t rescaledColor = (arg - RGB_CCT_COLOR_OFFSET) % 0x100;
     uint16_t hue = Units::rescale<uint16_t, uint16_t>(rescaledColor, 360, 255.0);
-    result["hue"] = hue;
+    result[GroupStateFieldNames::HUE] = hue;
   } else if (command == RGB_CCT_KELVIN) {
     uint8_t temperature = V2PacketFormatter::fromv2scale(arg, RGB_CCT_KELVIN_REMOTE_END, 2);
-    result["color_temp"] = Units::whiteValToMireds(temperature, 100);
+    result[GroupStateFieldNames::COLOR_TEMP] = Units::whiteValToMireds(temperature, 100);
   // brightness == saturation
   } else if (command == RGB_CCT_BRIGHTNESS && arg >= (RGB_CCT_BRIGHTNESS_OFFSET - 15)) {
     uint8_t level = constrain(arg - RGB_CCT_BRIGHTNESS_OFFSET, 0, 100);
-    result["brightness"] = Units::rescale<uint8_t, uint8_t>(level, 255, 100);
+    result[GroupStateFieldNames::BRIGHTNESS] = Units::rescale<uint8_t, uint8_t>(level, 255, 100);
   } else if (command == RGB_CCT_SATURATION) {
-    result["saturation"] = constrain(arg - RGB_CCT_SATURATION_OFFSET, 0, 100);
+    result[GroupStateFieldNames::SATURATION] = constrain(arg - RGB_CCT_SATURATION_OFFSET, 0, 100);
   } else if (command == RGB_CCT_MODE) {
-    result["mode"] = arg;
+    result[GroupStateFieldNames::MODE] = arg;
   } else {
     result["button_id"] = command;
     result["argument"] = arg;

--- a/lib/MiLight/RgbCctPacketFormatter.cpp
+++ b/lib/MiLight/RgbCctPacketFormatter.cpp
@@ -1,6 +1,7 @@
 #include <RgbCctPacketFormatter.h>
 #include <V2RFEncoding.h>
 #include <Units.h>
+#include <MiLightCommands.h>
 
 void RgbCctPacketFormatter::modeSpeedDown() {
   command(RGB_CCT_ON, RGB_CCT_MODE_SPEED_DOWN);
@@ -122,11 +123,11 @@ BulbId RgbCctPacketFormatter::parsePacket(const uint8_t *packet, JsonObject resu
 
   if (command == RGB_CCT_ON) {
     if ((packetCopy[V2_COMMAND_INDEX] & 0x80) == 0x80) {
-      result["command"] = "night_mode";
+      result["command"] = MiLightCommandNames::NIGHT_MODE;
     } else if (arg == RGB_CCT_MODE_SPEED_DOWN) {
-      result["command"] = "mode_speed_down";
+      result["command"] = MiLightCommandNames::MODE_SPEED_DOWN;
     } else if (arg == RGB_CCT_MODE_SPEED_UP) {
-      result["command"] = "mode_speed_up";
+      result["command"] = MiLightCommandNames::MODE_SPEED_UP;
     } else if (arg < 5) { // Group is not reliably encoded in group byte. Extract from arg byte
       result[GroupStateFieldNames::STATE] = "ON";
       bulbId.groupId = arg;

--- a/lib/MiLight/RgbCctPacketFormatter.cpp
+++ b/lib/MiLight/RgbCctPacketFormatter.cpp
@@ -123,11 +123,11 @@ BulbId RgbCctPacketFormatter::parsePacket(const uint8_t *packet, JsonObject resu
 
   if (command == RGB_CCT_ON) {
     if ((packetCopy[V2_COMMAND_INDEX] & 0x80) == 0x80) {
-      result["command"] = MiLightCommandNames::NIGHT_MODE;
+      result[GroupStateFieldNames::COMMAND] = MiLightCommandNames::NIGHT_MODE;
     } else if (arg == RGB_CCT_MODE_SPEED_DOWN) {
-      result["command"] = MiLightCommandNames::MODE_SPEED_DOWN;
+      result[GroupStateFieldNames::COMMAND] = MiLightCommandNames::MODE_SPEED_DOWN;
     } else if (arg == RGB_CCT_MODE_SPEED_UP) {
-      result["command"] = MiLightCommandNames::MODE_SPEED_UP;
+      result[GroupStateFieldNames::COMMAND] = MiLightCommandNames::MODE_SPEED_UP;
     } else if (arg < 5) { // Group is not reliably encoded in group byte. Extract from arg byte
       result[GroupStateFieldNames::STATE] = "ON";
       bulbId.groupId = arg;

--- a/lib/MiLight/RgbPacketFormatter.cpp
+++ b/lib/MiLight/RgbPacketFormatter.cpp
@@ -102,17 +102,17 @@ BulbId RgbPacketFormatter::parsePacket(const uint8_t* packet, JsonObject result)
     remappedColor = (remappedColor + 320) % 360;
     result[GroupStateFieldNames::HUE] = remappedColor;
   } else if (command == RGB_MODE_DOWN) {
-    result["command"] = MiLightCommandNames::PREVIOUS_MODE;
+    result[GroupStateFieldNames::COMMAND] = MiLightCommandNames::PREVIOUS_MODE;
   } else if (command == RGB_MODE_UP) {
-    result["command"] = MiLightCommandNames::NEXT_MODE;
+    result[GroupStateFieldNames::COMMAND] = MiLightCommandNames::NEXT_MODE;
   } else if (command == RGB_SPEED_DOWN) {
-    result["command"] = MiLightCommandNames::MODE_SPEED_DOWN;
+    result[GroupStateFieldNames::COMMAND] = MiLightCommandNames::MODE_SPEED_DOWN;
   } else if (command == RGB_SPEED_UP) {
-    result["command"] = MiLightCommandNames::MODE_SPEED_UP;
+    result[GroupStateFieldNames::COMMAND] = MiLightCommandNames::MODE_SPEED_UP;
   } else if (command == RGB_BRIGHTNESS_DOWN) {
-    result["command"] = "brightness_down";
+    result[GroupStateFieldNames::COMMAND] = "brightness_down";
   } else if (command == RGB_BRIGHTNESS_UP) {
-    result["command"] = "brightness_up";
+    result[GroupStateFieldNames::COMMAND] = "brightness_up";
   } else {
     result["button_id"] = command;
   }

--- a/lib/MiLight/RgbPacketFormatter.cpp
+++ b/lib/MiLight/RgbPacketFormatter.cpp
@@ -93,13 +93,13 @@ BulbId RgbPacketFormatter::parsePacket(const uint8_t* packet, JsonObject result)
   );
 
   if (command == RGB_ON) {
-    result["state"] = "ON";
+    result[GroupStateFieldNames::STATE] = "ON";
   } else if (command == RGB_OFF) {
-    result["state"] = "OFF";
+    result[GroupStateFieldNames::STATE] = "OFF";
   } else if (command == 0) {
     uint16_t remappedColor = Units::rescale<uint16_t, uint16_t>(packet[RGB_COLOR_INDEX], 360.0, 255.0);
     remappedColor = (remappedColor + 320) % 360;
-    result["hue"] = remappedColor;
+    result[GroupStateFieldNames::HUE] = remappedColor;
   } else if (command == RGB_MODE_DOWN) {
     result["command"] = "previous_mode";
   } else if (command == RGB_MODE_UP) {

--- a/lib/MiLight/RgbPacketFormatter.cpp
+++ b/lib/MiLight/RgbPacketFormatter.cpp
@@ -1,5 +1,6 @@
 #include <RgbPacketFormatter.h>
 #include <Units.h>
+#include <MiLightCommands.h>
 
 void RgbPacketFormatter::initializePacket(uint8_t *packet) {
   size_t packetPtr = 0;
@@ -101,13 +102,13 @@ BulbId RgbPacketFormatter::parsePacket(const uint8_t* packet, JsonObject result)
     remappedColor = (remappedColor + 320) % 360;
     result[GroupStateFieldNames::HUE] = remappedColor;
   } else if (command == RGB_MODE_DOWN) {
-    result["command"] = "previous_mode";
+    result["command"] = MiLightCommandNames::PREVIOUS_MODE;
   } else if (command == RGB_MODE_UP) {
-    result["command"] = "next_mode";
+    result["command"] = MiLightCommandNames::NEXT_MODE;
   } else if (command == RGB_SPEED_DOWN) {
-    result["command"] = "mode_speed_down";
+    result["command"] = MiLightCommandNames::MODE_SPEED_DOWN;
   } else if (command == RGB_SPEED_UP) {
-    result["command"] = "mode_speed_up";
+    result["command"] = MiLightCommandNames::MODE_SPEED_UP;
   } else if (command == RGB_BRIGHTNESS_DOWN) {
     result["command"] = "brightness_down";
   } else if (command == RGB_BRIGHTNESS_UP) {

--- a/lib/MiLight/RgbwPacketFormatter.cpp
+++ b/lib/MiLight/RgbwPacketFormatter.cpp
@@ -1,5 +1,6 @@
 #include <RgbwPacketFormatter.h>
 #include <Units.h>
+#include <MiLightCommands.h>
 
 #define STATUS_COMMAND(status, groupId) ( RGBW_GROUP_1_ON + (((groupId) - 1)*2) + (status) )
 #define GROUP_FOR_STATUS_COMMAND(buttonId) ( ((buttonId) - 1) / 2 )
@@ -126,9 +127,9 @@ BulbId RgbwPacketFormatter::parsePacket(const uint8_t* packet, JsonObject result
     bulbId.groupId = GROUP_FOR_STATUS_COMMAND(command);
   } else if (command & 0x10) {
     if ((command % 2) == 0) {
-      result["command"] = "night_mode";
+      result["command"] = MiLightCommandNames::NIGHT_MODE;
     } else {
-      result["command"] = "set_white";
+      result["command"] = MiLightCommandNames::SET_WHITE;
     }
     bulbId.groupId = GROUP_FOR_STATUS_COMMAND(command & 0xF);
   } else if (command == RGBW_BRIGHTNESS) {
@@ -142,9 +143,9 @@ BulbId RgbwPacketFormatter::parsePacket(const uint8_t* packet, JsonObject result
     remappedColor = (remappedColor + 320) % 360;
     result[GroupStateFieldNames::HUE] = remappedColor;
   } else if (command == RGBW_SPEED_DOWN) {
-    result["command"] = "mode_speed_down";
+    result["command"] = MiLightCommandNames::MODE_SPEED_DOWN;
   } else if (command == RGBW_SPEED_UP) {
-    result["command"] = "mode_speed_up";
+    result["command"] = MiLightCommandNames::MODE_SPEED_UP;
   } else if (command == RGBW_DISCO_MODE) {
     result[GroupStateFieldNames::MODE] = packet[0] & ~RGBW_PROTOCOL_ID_BYTE;
   } else {

--- a/lib/MiLight/RgbwPacketFormatter.cpp
+++ b/lib/MiLight/RgbwPacketFormatter.cpp
@@ -127,9 +127,9 @@ BulbId RgbwPacketFormatter::parsePacket(const uint8_t* packet, JsonObject result
     bulbId.groupId = GROUP_FOR_STATUS_COMMAND(command);
   } else if (command & 0x10) {
     if ((command % 2) == 0) {
-      result["command"] = MiLightCommandNames::NIGHT_MODE;
+      result[GroupStateFieldNames::COMMAND] = MiLightCommandNames::NIGHT_MODE;
     } else {
-      result["command"] = MiLightCommandNames::SET_WHITE;
+      result[GroupStateFieldNames::COMMAND] = MiLightCommandNames::SET_WHITE;
     }
     bulbId.groupId = GROUP_FOR_STATUS_COMMAND(command & 0xF);
   } else if (command == RGBW_BRIGHTNESS) {
@@ -143,9 +143,9 @@ BulbId RgbwPacketFormatter::parsePacket(const uint8_t* packet, JsonObject result
     remappedColor = (remappedColor + 320) % 360;
     result[GroupStateFieldNames::HUE] = remappedColor;
   } else if (command == RGBW_SPEED_DOWN) {
-    result["command"] = MiLightCommandNames::MODE_SPEED_DOWN;
+    result[GroupStateFieldNames::COMMAND] = MiLightCommandNames::MODE_SPEED_DOWN;
   } else if (command == RGBW_SPEED_UP) {
-    result["command"] = MiLightCommandNames::MODE_SPEED_UP;
+    result[GroupStateFieldNames::COMMAND] = MiLightCommandNames::MODE_SPEED_UP;
   } else if (command == RGBW_DISCO_MODE) {
     result[GroupStateFieldNames::MODE] = packet[0] & ~RGBW_PROTOCOL_ID_BYTE;
   } else {

--- a/lib/MiLight/RgbwPacketFormatter.cpp
+++ b/lib/MiLight/RgbwPacketFormatter.cpp
@@ -118,7 +118,7 @@ BulbId RgbwPacketFormatter::parsePacket(const uint8_t* packet, JsonObject result
   );
 
   if (command >= RGBW_ALL_ON && command <= RGBW_GROUP_4_OFF) {
-    result["state"] = (STATUS_FOR_COMMAND(command) == ON) ? "ON" : "OFF";
+    result[GroupStateFieldNames::STATE] = (STATUS_FOR_COMMAND(command) == ON) ? "ON" : "OFF";
 
     // Determine group ID from button ID for on/off. The remote's state is from
     // the last packet sent, not the current one, and that can be wrong for
@@ -136,17 +136,17 @@ BulbId RgbwPacketFormatter::parsePacket(const uint8_t* packet, JsonObject result
     brightness -= packet[RGBW_BRIGHTNESS_GROUP_INDEX] >> 3;
     brightness += 17;
     brightness %= 32;
-    result["brightness"] = Units::rescale<uint8_t, uint8_t>(brightness, 255, 25);
+    result[GroupStateFieldNames::BRIGHTNESS] = Units::rescale<uint8_t, uint8_t>(brightness, 255, 25);
   } else if (command == RGBW_COLOR) {
     uint16_t remappedColor = Units::rescale<uint16_t, uint16_t>(packet[RGBW_COLOR_INDEX], 360.0, 255.0);
     remappedColor = (remappedColor + 320) % 360;
-    result["hue"] = remappedColor;
+    result[GroupStateFieldNames::HUE] = remappedColor;
   } else if (command == RGBW_SPEED_DOWN) {
     result["command"] = "mode_speed_down";
   } else if (command == RGBW_SPEED_UP) {
     result["command"] = "mode_speed_up";
   } else if (command == RGBW_DISCO_MODE) {
-    result["mode"] = packet[0] & ~RGBW_PROTOCOL_ID_BYTE;
+    result[GroupStateFieldNames::MODE] = packet[0] & ~RGBW_PROTOCOL_ID_BYTE;
   } else {
     result["button_id"] = command;
   }

--- a/lib/MiLightState/GroupState.cpp
+++ b/lib/MiLightState/GroupState.cpp
@@ -276,6 +276,19 @@ uint16_t GroupState::getFieldValue(GroupStateField field) const {
   return 0;
 }
 
+uint16_t GroupState::getParsedFieldValue(GroupStateField field) const {
+  switch (field) {
+    case GroupStateField::LEVEL:
+      return getBrightness();
+    case GroupStateField::BRIGHTNESS:
+      return Units::rescale(getBrightness(), 255, 100);
+    case GroupStateField::COLOR_TEMP:
+      return getMireds();
+    default:
+      return getFieldValue(field);
+  }
+}
+
 uint16_t GroupState::getScratchFieldValue(GroupStateField field) const {
   switch (field) {
     case GroupStateField::BRIGHTNESS:

--- a/lib/MiLightState/GroupState.cpp
+++ b/lib/MiLightState/GroupState.cpp
@@ -745,8 +745,8 @@ bool GroupState::patch(JsonObject state) {
     changes |= setBulbMode(BULB_MODE_WHITE);
   }
 
-  if (state.containsKey("command")) {
-    const String& command = state["command"];
+  if (state.containsKey(GroupStateFieldNames::COMMAND)) {
+    const String& command = state[GroupStateFieldNames::COMMAND];
 
     if (isOn() && command == MiLightCommandNames::SET_WHITE) {
       changes |= setBulbMode(BULB_MODE_WHITE);

--- a/lib/MiLightState/GroupState.cpp
+++ b/lib/MiLightState/GroupState.cpp
@@ -3,6 +3,7 @@
 #include <MiLightRemoteConfig.h>
 #include <RGBConverter.h>
 #include <BulbId.h>
+#include <MiLightCommands.h>
 
 static const char* BULB_MODE_NAMES[] = {
   "white",
@@ -747,18 +748,18 @@ bool GroupState::patch(JsonObject state) {
   if (state.containsKey("command")) {
     const String& command = state["command"];
 
-    if (isOn() && command == "set_white") {
+    if (isOn() && command == MiLightCommandNames::SET_WHITE) {
       changes |= setBulbMode(BULB_MODE_WHITE);
-    } else if (command == "night_mode") {
+    } else if (command == MiLightCommandNames::NIGHT_MODE) {
       changes |= setBulbMode(BULB_MODE_NIGHT);
     } else if (isOn() && command == "brightness_up") {
       changes |= applyIncrementCommand(GroupStateField::BRIGHTNESS, IncrementDirection::INCREASE);
     } else if (isOn() && command == "brightness_down") {
       changes |= applyIncrementCommand(GroupStateField::BRIGHTNESS, IncrementDirection::DECREASE);
-    } else if (isOn() && command == "temperature_up") {
+    } else if (isOn() && command == MiLightCommandNames::TEMPERATURE_UP) {
       changes |= applyIncrementCommand(GroupStateField::KELVIN, IncrementDirection::INCREASE);
       changes |= setBulbMode(BULB_MODE_WHITE);
-    } else if (isOn() && command == "temperature_down") {
+    } else if (isOn() && command == MiLightCommandNames::TEMPERATURE_DOWN) {
       changes |= applyIncrementCommand(GroupStateField::KELVIN, IncrementDirection::DECREASE);
       changes |= setBulbMode(BULB_MODE_WHITE);
     }
@@ -874,7 +875,7 @@ void GroupState::applyField(JsonObject partialState, const BulbId& bulbId, Group
         } else if (isSetBulbMode() && getBulbMode() == BULB_MODE_WHITE) {
           partialState[GroupStateFieldNames::EFFECT] = "white_mode";
         } else if (getBulbMode() == BULB_MODE_NIGHT) {
-          partialState[GroupStateFieldNames::EFFECT] = "night_mode";
+          partialState[GroupStateFieldNames::EFFECT] = MiLightCommandNames::NIGHT_MODE;
         }
         break;
 

--- a/lib/MiLightState/GroupState.cpp
+++ b/lib/MiLightState/GroupState.cpp
@@ -776,16 +776,8 @@ bool GroupState::patch(JsonObject state) {
 }
 
 void GroupState::applyColor(JsonObject state) const {
-  uint8_t rgb[3];
-  RGBConverter converter;
-  converter.hsvToRgb(
-    getHue()/360.0,
-    // Default to fully saturated
-    (isSetSaturation() ? getSaturation() : 100)/100.0,
-    1,
-    rgb
-  );
-  applyColor(state, rgb[0], rgb[1], rgb[2]);
+  ParsedColor color = getColor();
+  applyColor(state, color.r, color.g, color.b);
 }
 
 void GroupState::applyColor(JsonObject state, uint8_t r, uint8_t g, uint8_t b) const {
@@ -946,6 +938,34 @@ void GroupState::debugState(char const *debugMessage) const {
   Serial.println("");
   Serial.printf("Raw data: %08X %08X\n", state.rawData[0], state.rawData[1]);
 #endif
+}
+
+bool GroupState::isSetColor() const {
+  return isSetHue();
+}
+
+ParsedColor GroupState::getColor() const {
+  uint8_t rgb[3];
+  RGBConverter converter;
+  uint16_t hue = getHue();
+  uint8_t sat = isSetSaturation() ? getSaturation() : 100;
+
+  converter.hsvToRgb(
+    hue / 360.0,
+    // Default to fully saturated
+    sat / 100.0,
+    1,
+    rgb
+  );
+
+  return {
+    .success = true,
+    .hue = hue,
+    .r = rgb[0],
+    .g = rgb[1],
+    .b = rgb[2],
+    .saturation = sat
+  };
 }
 
 // build up a partial state representation based on the specified GrouipStateField array.  Used

--- a/lib/MiLightState/GroupState.cpp
+++ b/lib/MiLightState/GroupState.cpp
@@ -13,7 +13,7 @@ static const char* BULB_MODE_NAMES[] = {
 
 const BulbId DEFAULT_BULB_ID;
 
-static const GroupStateField ALL_PHYSICAL_FIELDS[] = {
+const GroupStateField GroupState::ALL_PHYSICAL_FIELDS[] = {
   GroupStateField::BULB_MODE,
   GroupStateField::HUE,
   GroupStateField::KELVIN,
@@ -953,4 +953,13 @@ void GroupState::applyState(JsonObject partialState, const BulbId& bulbId, std::
   for (std::vector<GroupStateField>::const_iterator itr = fields.begin(); itr != fields.end(); ++itr) {
     applyField(partialState, bulbId, *itr);
   }
+}
+
+bool GroupState::isPhysicalField(GroupStateField field) {
+  for (size_t i = 0; i < size(ALL_PHYSICAL_FIELDS); ++i) {
+    if (field == ALL_PHYSICAL_FIELDS[i]) {
+      return true;
+    }
+  }
+  return false;
 }

--- a/lib/MiLightState/GroupState.cpp
+++ b/lib/MiLightState/GroupState.cpp
@@ -716,31 +716,31 @@ bool GroupState::patch(JsonObject state) {
   Serial.println();
 #endif
 
-  if (state.containsKey("state")) {
-    bool stateChange = setState(state["state"] == "ON" ? ON : OFF);
+  if (state.containsKey(GroupStateFieldNames::STATE)) {
+    bool stateChange = setState(state[GroupStateFieldNames::STATE] == "ON" ? ON : OFF);
     changes |= stateChange;
   }
 
   // Devices do not support changing their state while off, so don't apply state
   // changes to devices we know are off.
 
-  if (isOn() && state.containsKey("brightness")) {
-    bool stateChange = setBrightness(Units::rescale(state["brightness"].as<uint8_t>(), 100, 255));
+  if (isOn() && state.containsKey(GroupStateFieldNames::BRIGHTNESS)) {
+    bool stateChange = setBrightness(Units::rescale(state[GroupStateFieldNames::BRIGHTNESS].as<uint8_t>(), 100, 255));
     changes |= stateChange;
   }
-  if (isOn() && state.containsKey("hue")) {
-    changes |= setHue(state["hue"]);
+  if (isOn() && state.containsKey(GroupStateFieldNames::HUE)) {
+    changes |= setHue(state[GroupStateFieldNames::HUE]);
     changes |= setBulbMode(BULB_MODE_COLOR);
   }
-  if (isOn() && state.containsKey("saturation")) {
-    changes |= setSaturation(state["saturation"]);
+  if (isOn() && state.containsKey(GroupStateFieldNames::SATURATION)) {
+    changes |= setSaturation(state[GroupStateFieldNames::SATURATION]);
   }
-  if (isOn() && state.containsKey("mode")) {
-    changes |= setMode(state["mode"]);
+  if (isOn() && state.containsKey(GroupStateFieldNames::MODE)) {
+    changes |= setMode(state[GroupStateFieldNames::MODE]);
     changes |= setBulbMode(BULB_MODE_SCENE);
   }
-  if (isOn() && state.containsKey("color_temp")) {
-    changes |= setMireds(state["color_temp"]);
+  if (isOn() && state.containsKey(GroupStateFieldNames::COLOR_TEMP)) {
+    changes |= setMireds(state[GroupStateFieldNames::COLOR_TEMP]);
     changes |= setBulbMode(BULB_MODE_WHITE);
   }
 
@@ -788,7 +788,7 @@ void GroupState::applyColor(JsonObject state) const {
 }
 
 void GroupState::applyColor(JsonObject state, uint8_t r, uint8_t g, uint8_t b) const {
-  JsonObject color = state.createNestedObject("color");
+  JsonObject color = state.createNestedObject(GroupStateFieldNames::COLOR);
   color["r"] = r;
   color["g"] = g;
   color["b"] = b;
@@ -806,7 +806,7 @@ void GroupState::applyOhColor(JsonObject state) const {
   );
   char ohColorStr[13];
   sprintf(ohColorStr, "%d,%d,%d", rgb[0], rgb[1], rgb[2]);
-  state["color"] = ohColorStr;
+  state[GroupStateFieldNames::COLOR] = ohColorStr;
 }
 
 // gather partial state for a single field; see GroupState::applyState to gather many fields
@@ -819,15 +819,15 @@ void GroupState::applyField(JsonObject partialState, const BulbId& bulbId, Group
         break;
 
       case GroupStateField::BRIGHTNESS:
-        partialState["brightness"] = Units::rescale(getBrightness(), 255, 100);
+        partialState[GroupStateFieldNames::BRIGHTNESS] = Units::rescale(getBrightness(), 255, 100);
         break;
 
       case GroupStateField::LEVEL:
-        partialState["level"] = getBrightness();
+        partialState[GroupStateFieldNames::LEVEL] = getBrightness();
         break;
 
       case GroupStateField::BULB_MODE:
-        partialState["bulb_mode"] = BULB_MODE_NAMES[getBulbMode()];
+        partialState[GroupStateFieldNames::BULB_MODE] = BULB_MODE_NAMES[getBulbMode()];
         break;
 
       case GroupStateField::COLOR:
@@ -852,57 +852,57 @@ void GroupState::applyField(JsonObject partialState, const BulbId& bulbId, Group
 
       case GroupStateField::HUE:
         if (getBulbMode() == BULB_MODE_COLOR) {
-          partialState["hue"] = getHue();
+          partialState[GroupStateFieldNames::HUE] = getHue();
         }
         break;
 
       case GroupStateField::SATURATION:
         if (getBulbMode() == BULB_MODE_COLOR) {
-          partialState["saturation"] = getSaturation();
+          partialState[GroupStateFieldNames::SATURATION] = getSaturation();
         }
         break;
 
       case GroupStateField::MODE:
         if (getBulbMode() == BULB_MODE_SCENE) {
-          partialState["mode"] = getMode();
+          partialState[GroupStateFieldNames::MODE] = getMode();
         }
         break;
 
       case GroupStateField::EFFECT:
         if (getBulbMode() == BULB_MODE_SCENE) {
-          partialState["effect"] = String(getMode());
+          partialState[GroupStateFieldNames::EFFECT] = String(getMode());
         } else if (isSetBulbMode() && getBulbMode() == BULB_MODE_WHITE) {
-          partialState["effect"] = "white_mode";
+          partialState[GroupStateFieldNames::EFFECT] = "white_mode";
         } else if (getBulbMode() == BULB_MODE_NIGHT) {
-          partialState["effect"] = "night_mode";
+          partialState[GroupStateFieldNames::EFFECT] = "night_mode";
         }
         break;
 
       case GroupStateField::COLOR_TEMP:
         if (isSetBulbMode() && getBulbMode() == BULB_MODE_WHITE) {
-          partialState["color_temp"] = getMireds();
+          partialState[GroupStateFieldNames::COLOR_TEMP] = getMireds();
         }
         break;
 
       case GroupStateField::KELVIN:
         if (isSetBulbMode() && getBulbMode() == BULB_MODE_WHITE) {
-          partialState["kelvin"] = getKelvin();
+          partialState[GroupStateFieldNames::KELVIN] = getKelvin();
         }
         break;
 
       case GroupStateField::DEVICE_ID:
-        partialState["device_id"] = bulbId.deviceId;
+        partialState[GroupStateFieldNames::DEVICE_ID] = bulbId.deviceId;
         break;
 
       case GroupStateField::GROUP_ID:
-        partialState["group_id"] = bulbId.groupId;
+        partialState[GroupStateFieldNames::GROUP_ID] = bulbId.groupId;
         break;
 
       case GroupStateField::DEVICE_TYPE:
         {
           const MiLightRemoteConfig* remoteConfig = MiLightRemoteConfig::fromType(bulbId.deviceType);
           if (remoteConfig) {
-            partialState["device_type"] = remoteConfig->name;
+            partialState[GroupStateFieldNames::DEVICE_TYPE] = remoteConfig->name;
           }
         }
         break;

--- a/lib/MiLightState/GroupState.h
+++ b/lib/MiLightState/GroupState.h
@@ -27,6 +27,7 @@ enum class IncrementDirection : unsigned {
 
 class GroupState {
 public:
+  static const GroupStateField ALL_PHYSICAL_FIELDS[];
 
   GroupState();
   GroupState(const GroupState& other);
@@ -145,6 +146,7 @@ public:
   void debugState(char const *debugMessage) const;
 
   static const GroupState& defaultState(MiLightRemoteType remoteType);
+  static bool isPhysicalField(GroupStateField field);
 
 private:
   static const size_t DATA_LONGS = 2;

--- a/lib/MiLightState/GroupState.h
+++ b/lib/MiLightState/GroupState.h
@@ -46,6 +46,7 @@ public:
 
   bool isSetField(GroupStateField field) const;
   uint16_t getFieldValue(GroupStateField field) const;
+  uint16_t getParsedFieldValue(GroupStateField field) const;
   void setFieldValue(GroupStateField field, uint16_t value);
   bool clearField(GroupStateField field);
 

--- a/lib/MiLightState/GroupState.h
+++ b/lib/MiLightState/GroupState.h
@@ -6,6 +6,7 @@
 #include <GroupStateField.h>
 #include <ArduinoJson.h>
 #include <BulbId.h>
+#include <ParsedColor.h>
 
 #ifndef _GROUP_STATE_H
 #define _GROUP_STATE_H
@@ -139,6 +140,12 @@ public:
   //
   // returns true if a (real, not scratch) state change was made
   bool applyIncrementCommand(GroupStateField field, IncrementDirection dir);
+
+  // Helpers that convert raw state values
+
+  // Return true if hue is set.  If saturation is not set, will assume 100.
+  bool isSetColor() const;
+  ParsedColor getColor() const;
 
   void load(Stream& stream);
   void dump(Stream& stream) const;

--- a/lib/MiLightState/GroupStateCache.cpp
+++ b/lib/MiLightState/GroupStateCache.cpp
@@ -4,6 +4,15 @@ GroupStateCache::GroupStateCache(const size_t maxSize)
   : maxSize(maxSize)
 { }
 
+GroupStateCache::~GroupStateCache() {
+  ListNode<GroupCacheNode*>* cur = cache.getHead();
+
+  while (cur != NULL) {
+    delete cur->data;
+    cur = cur->next;
+  }
+}
+
 GroupState* GroupStateCache::get(const BulbId& id) {
   return getInternal(id);
 }

--- a/lib/MiLightState/GroupStateCache.h
+++ b/lib/MiLightState/GroupStateCache.h
@@ -16,6 +16,7 @@ struct GroupCacheNode {
 class GroupStateCache {
 public:
   GroupStateCache(const size_t maxSize);
+  ~GroupStateCache();
 
   GroupState* get(const BulbId& id);
   GroupState* set(const BulbId& id, const GroupState& state);

--- a/lib/MiLightState/GroupStateStore.h
+++ b/lib/MiLightState/GroupStateStore.h
@@ -11,9 +11,9 @@ public:
 
   /*
    * Returns the state for the given BulbId.  If accessing state for a valid device
-   * (i.e., NOT group 0) and no state exists, its state will be initialized with a 
+   * (i.e., NOT group 0) and no state exists, its state will be initialized with a
    * default.
-   * 
+   *
    * Otherwise, we return NULL.
    */
   GroupState* get(const BulbId& id);

--- a/lib/Transitions/ColorTransition.cpp
+++ b/lib/Transitions/ColorTransition.cpp
@@ -73,6 +73,7 @@ ColorTransition::ColorTransition(
   , stepSizes(stepSizes)
   , lastHue(400)         // use impossible values to force a packet send
   , lastSaturation(200)
+  , finished(false)
 {
   int16_t dr = endColor.r - startColor.r
         , dg = endColor.g - startColor.g
@@ -118,13 +119,17 @@ void ColorTransition::step() {
     lastSaturation = parsedColor.saturation;
   }
 
-  Transition::stepValue(currentColor.r, endColor.r, stepSizes.r);
-  Transition::stepValue(currentColor.g, endColor.g, stepSizes.g);
-  Transition::stepValue(currentColor.b, endColor.b, stepSizes.b);
+  if (currentColor == endColor) {
+    finished = true;
+  } else {
+    Transition::stepValue(currentColor.r, endColor.r, stepSizes.r);
+    Transition::stepValue(currentColor.g, endColor.g, stepSizes.g);
+    Transition::stepValue(currentColor.b, endColor.b, stepSizes.b);
+  }
 }
 
 bool ColorTransition::isFinished() {
-  return currentColor == endColor;
+  return finished;
 }
 
 void ColorTransition::childSerialize(JsonObject& json) {

--- a/lib/Transitions/ColorTransition.cpp
+++ b/lib/Transitions/ColorTransition.cpp
@@ -1,0 +1,84 @@
+#include <ColorTransition.h>
+#include <Arduino.h>
+
+ColorTransition::RgbColor::RgbColor()
+  : r(0)
+  , g(0)
+  , b(0)
+{ }
+
+ColorTransition::RgbColor::RgbColor(const ParsedColor& color)
+  : r(color.r)
+  , g(color.g)
+  , b(color.b)
+{ }
+
+bool ColorTransition::RgbColor::operator==(const RgbColor& other) {
+  return r == other.r && g == other.g && b == other.b;
+}
+
+ColorTransition::ColorTransition(
+  size_t id,
+  const ParsedColor& startColor,
+  const ParsedColor& endColor,
+  uint16_t stepSize,
+  size_t duration,
+  TransitionFn callback
+) : endColor(endColor)
+  , currentColor(startColor)
+  , lastHue(400)         // use impossible values to force a packet send
+  , lastSaturation(200)
+  , Transition(id, stepSize, calculateColorPeriod(this, startColor, endColor, stepSize, duration), callback)
+{
+  int16_t dr = endColor.r - startColor.r
+        , dg = endColor.g - startColor.g
+        , db = endColor.b - startColor.b;
+  // Calculate step sizes in terms of the period
+  stepSizes.r = calculateStepSizePart(dr, duration, period);
+  stepSizes.g = calculateStepSizePart(dg, duration, period);
+  stepSizes.b = calculateStepSizePart(db, duration, period);
+}
+
+size_t ColorTransition::calculateColorPeriod(ColorTransition* t, const ParsedColor& start, const ParsedColor& end, size_t stepSize, size_t duration) {
+  int16_t dr = end.r - start.r
+        , dg = end.g - start.g
+        , db = end.b - start.b;
+
+  int16_t max = std::max(std::max(dr, dg), db);
+  int16_t min = std::min(std::min(dr, dg), db);
+  int16_t maxAbs = std::abs(min) > std::abs(max) ? min : max;
+
+  return Transition::calculatePeriod(maxAbs, stepSize, duration);
+}
+
+int16_t ColorTransition::calculateStepSizePart(int16_t distance, size_t duration, size_t period) {
+  double stepSize = (distance / static_cast<double>(duration)) * period;
+  int16_t rounded = std::ceil(std::abs(stepSize));
+
+  if (distance < 0) {
+    rounded = -rounded;
+  }
+
+  return rounded;
+}
+
+void ColorTransition::step() {
+  ParsedColor parsedColor = ParsedColor::fromRgb(currentColor.r, currentColor.g, currentColor.b);
+
+  if (parsedColor.hue != lastHue) {
+    callback(GroupStateField::HUE, parsedColor.hue);
+    lastHue = parsedColor.hue;
+  }
+  if (parsedColor.saturation != lastSaturation) {
+    callback(GroupStateField::SATURATION, parsedColor.saturation);
+    lastSaturation = parsedColor.saturation;
+  }
+
+  Transition::stepValue(currentColor.r, endColor.r, stepSizes.r);
+  Transition::stepValue(currentColor.g, endColor.g, stepSizes.g);
+  Transition::stepValue(currentColor.b, endColor.b, stepSizes.b);
+}
+
+bool ColorTransition::isFinished() {
+  return currentColor == endColor;
+}

--- a/lib/Transitions/ColorTransition.cpp
+++ b/lib/Transitions/ColorTransition.cpp
@@ -133,19 +133,19 @@ bool ColorTransition::isFinished() {
 }
 
 void ColorTransition::childSerialize(JsonObject& json) {
-  json["type"] = "color";
+  json[F("type")] = F("color");
 
-  JsonArray currentColorArr = json.createNestedArray("current_color");
+  JsonArray currentColorArr = json.createNestedArray(F("current_color"));
   currentColorArr.add(currentColor.r);
   currentColorArr.add(currentColor.g);
   currentColorArr.add(currentColor.b);
 
-  JsonArray endColorArr = json.createNestedArray("end_color");
+  JsonArray endColorArr = json.createNestedArray(F("end_color"));
   endColorArr.add(endColor.r);
   endColorArr.add(endColor.g);
   endColorArr.add(endColor.b);
 
-  JsonArray stepSizesArr = json.createNestedArray("step_sizes");
+  JsonArray stepSizesArr = json.createNestedArray(F("step_sizes"));
   stepSizesArr.add(stepSizes.r);
   stepSizesArr.add(stepSizes.g);
   stepSizesArr.add(stepSizes.b);

--- a/lib/Transitions/ColorTransition.h
+++ b/lib/Transitions/ColorTransition.h
@@ -5,13 +5,36 @@
 
 class ColorTransition : public Transition {
 public:
+  struct RgbColor {
+    RgbColor();
+    RgbColor(const ParsedColor& color);
+    RgbColor(int16_t r, int16_t g, int16_t b);
+    bool operator==(const RgbColor& other);
+
+    int16_t r, g, b;
+  };
+
+  class Builder : public Transition::Builder {
+  public:
+    Builder(size_t id, const BulbId& bulbId, TransitionFn callback, const ParsedColor& start, const ParsedColor& end);
+
+    virtual std::shared_ptr<Transition> _build() const override;
+
+  private:
+    const ParsedColor& start;
+    const ParsedColor& end;
+    RgbColor stepSizes;
+  };
+
   ColorTransition(
     size_t id,
     const BulbId& bulbId,
     const ParsedColor& startColor,
     const ParsedColor& endColor,
-    uint16_t stepSize,
+    RgbColor stepSizes,
     size_t duration,
+    size_t period,
+    size_t numPeriods,
     TransitionFn callback
   );
 
@@ -20,14 +43,6 @@ public:
   virtual bool isFinished() override;
 
 protected:
-  struct RgbColor {
-    RgbColor();
-    RgbColor(const ParsedColor& color);
-    bool operator==(const RgbColor& other);
-
-    int16_t r, g, b;
-  };
-
   const RgbColor endColor;
   RgbColor currentColor;
   RgbColor stepSizes;

--- a/lib/Transitions/ColorTransition.h
+++ b/lib/Transitions/ColorTransition.h
@@ -50,6 +50,7 @@ protected:
   // Store these to avoid wasted packets
   uint16_t lastHue;
   uint16_t lastSaturation;
+  bool finished;
 
   virtual void step() override;
   virtual void childSerialize(JsonObject& json) override;

--- a/lib/Transitions/ColorTransition.h
+++ b/lib/Transitions/ColorTransition.h
@@ -1,0 +1,40 @@
+#include <Transition.h>
+#include <ParsedColor.h>
+
+#pragma once
+
+class ColorTransition : public Transition {
+public:
+  ColorTransition(
+    size_t id,
+    const ParsedColor& startColor,
+    const ParsedColor& endColor,
+    uint16_t stepSize,
+    size_t duration,
+    TransitionFn callback
+  );
+
+  static size_t calculateColorPeriod(ColorTransition* t, const ParsedColor& start, const ParsedColor& end, size_t stepSize, size_t duration);
+  inline static int16_t calculateStepSizePart(int16_t distance, size_t duration, size_t period);
+  virtual bool isFinished() override;
+
+protected:
+  struct RgbColor {
+    RgbColor();
+    RgbColor(const ParsedColor& color);
+    bool operator==(const RgbColor& other);
+
+    int16_t r, g, b;
+  };
+
+  const RgbColor endColor;
+  RgbColor currentColor;
+  RgbColor stepSizes;
+
+  // Store these to avoid wasted packets
+  uint16_t lastHue;
+  uint16_t lastSaturation;
+
+  virtual void step() override;
+  static inline void stepPart(uint16_t& current, uint16_t end, int16_t step);
+};

--- a/lib/Transitions/ColorTransition.h
+++ b/lib/Transitions/ColorTransition.h
@@ -7,6 +7,7 @@ class ColorTransition : public Transition {
 public:
   ColorTransition(
     size_t id,
+    const BulbId& bulbId,
     const ParsedColor& startColor,
     const ParsedColor& endColor,
     uint16_t stepSize,
@@ -36,5 +37,6 @@ protected:
   uint16_t lastSaturation;
 
   virtual void step() override;
+  virtual void childSerialize(JsonObject& json) override;
   static inline void stepPart(uint16_t& current, uint16_t end, int16_t step);
 };

--- a/lib/Transitions/FieldTransition.cpp
+++ b/lib/Transitions/FieldTransition.cpp
@@ -64,9 +64,9 @@ bool FieldTransition::isFinished() {
 }
 
 void FieldTransition::childSerialize(JsonObject& json) {
-  json["type"] = "field";
-  json["field"] = GroupStateFieldHelpers::getFieldName(field);
-  json["current_value"] = currentValue;
-  json["end_value"] = endValue;
-  json["step_size"] = stepSize;
+  json[F("type")] = F("field");
+  json[F("field")] = GroupStateFieldHelpers::getFieldName(field);
+  json[F("current_value")] = currentValue;
+  json[F("end_value")] = endValue;
+  json[F("step_size")] = stepSize;
 }

--- a/lib/Transitions/FieldTransition.cpp
+++ b/lib/Transitions/FieldTransition.cpp
@@ -1,26 +1,50 @@
 #include <FieldTransition.h>
 #include <cmath>
 
+FieldTransition::Builder::Builder(size_t id, const BulbId& bulbId, TransitionFn callback, GroupStateField field, uint16_t start, uint16_t end)
+  : Transition::Builder(id, bulbId, callback)
+  , stepSize(0)
+  , field(field)
+  , start(start)
+  , end(end)
+{ }
+
+std::shared_ptr<Transition> FieldTransition::Builder::_build() const {
+  size_t duration = getOrComputeDuration();
+  size_t numPeriods = getOrComputeNumPeriods();
+  size_t period = getOrComputePeriod();
+  int16_t distance = end - start;
+  int16_t stepSize = distance / numPeriods;
+
+  return std::make_shared<FieldTransition>(
+    id,
+    bulbId,
+    field,
+    start,
+    end,
+    stepSize,
+    duration,
+    period,
+    callback
+  );
+}
+
 FieldTransition::FieldTransition(
   size_t id,
   const BulbId& bulbId,
   GroupStateField field,
   uint16_t startValue,
   uint16_t endValue,
-  uint16_t stepSize,
+  int16_t stepSize,
   size_t duration,
+  size_t period,
   TransitionFn callback
-) : Transition(id, bulbId, stepSize, calculatePeriod((endValue - startValue), stepSize, duration), callback)
+) : Transition(id, bulbId, period, callback)
   , field(field)
   , currentValue(startValue)
   , endValue(endValue)
-{
-  if (endValue < startValue) {
-    stepSize = -stepSize;
-  } else if (endValue == startValue) {
-    stepSize = 0;
-  }
-}
+  , stepSize(stepSize)
+{ }
 
 void FieldTransition::step() {
   callback(bulbId, field, currentValue);

--- a/lib/Transitions/FieldTransition.cpp
+++ b/lib/Transitions/FieldTransition.cpp
@@ -1,5 +1,6 @@
 #include <FieldTransition.h>
 #include <cmath>
+#include <algorithm>
 
 FieldTransition::Builder::Builder(size_t id, const BulbId& bulbId, TransitionFn callback, GroupStateField field, uint16_t start, uint16_t end)
   : Transition::Builder(id, bulbId, callback)
@@ -14,7 +15,14 @@ std::shared_ptr<Transition> FieldTransition::Builder::_build() const {
   size_t numPeriods = getOrComputeNumPeriods();
   size_t period = getOrComputePeriod();
   int16_t distance = end - start;
-  int16_t stepSize = distance / numPeriods;
+  int16_t stepSize = ceil(std::abs(distance / static_cast<float>(numPeriods)));
+
+  if (end < start) {
+    stepSize = -stepSize;
+  }
+  if (stepSize == 0) {
+    stepSize = end > start ? 1 : -1;
+  }
 
   return std::make_shared<FieldTransition>(
     id,

--- a/lib/Transitions/FieldTransition.cpp
+++ b/lib/Transitions/FieldTransition.cpp
@@ -3,13 +3,14 @@
 
 FieldTransition::FieldTransition(
   size_t id,
+  const BulbId& bulbId,
   GroupStateField field,
   uint16_t startValue,
   uint16_t endValue,
   uint16_t stepSize,
   size_t duration,
   TransitionFn callback
-) : Transition(id, stepSize, calculatePeriod((endValue - startValue), stepSize, duration), callback)
+) : Transition(id, bulbId, stepSize, calculatePeriod((endValue - startValue), stepSize, duration), callback)
   , field(field)
   , currentValue(startValue)
   , endValue(endValue)
@@ -22,10 +23,18 @@ FieldTransition::FieldTransition(
 }
 
 void FieldTransition::step() {
-  callback(field, currentValue);
+  callback(bulbId, field, currentValue);
   Transition::stepValue(currentValue, endValue, stepSize);
 }
 
 bool FieldTransition::isFinished() {
   return currentValue == endValue;
+}
+
+void FieldTransition::childSerialize(JsonObject& json) {
+  json["type"] = "field";
+  json["field"] = GroupStateFieldHelpers::getFieldName(field);
+  json["current_value"] = currentValue;
+  json["end_value"] = endValue;
+  json["step_size"] = stepSize;
 }

--- a/lib/Transitions/FieldTransition.cpp
+++ b/lib/Transitions/FieldTransition.cpp
@@ -50,15 +50,21 @@ FieldTransition::FieldTransition(
   , currentValue(startValue)
   , endValue(endValue)
   , stepSize(stepSize)
+  , finished(false)
 { }
 
 void FieldTransition::step() {
   callback(bulbId, field, currentValue);
-  Transition::stepValue(currentValue, endValue, stepSize);
+
+  if (currentValue != endValue) {
+    Transition::stepValue(currentValue, endValue, stepSize);
+  } else {
+    finished = true;
+  }
 }
 
 bool FieldTransition::isFinished() {
-  return currentValue == endValue;
+  return finished;
 }
 
 void FieldTransition::childSerialize(JsonObject& json) {

--- a/lib/Transitions/FieldTransition.cpp
+++ b/lib/Transitions/FieldTransition.cpp
@@ -1,0 +1,31 @@
+#include <FieldTransition.h>
+#include <cmath>
+
+FieldTransition::FieldTransition(
+  size_t id,
+  GroupStateField field,
+  uint16_t startValue,
+  uint16_t endValue,
+  uint16_t stepSize,
+  size_t duration,
+  TransitionFn callback
+) : Transition(id, stepSize, calculatePeriod((endValue - startValue), stepSize, duration), callback)
+  , field(field)
+  , currentValue(startValue)
+  , endValue(endValue)
+{
+  if (endValue < startValue) {
+    stepSize = -stepSize;
+  } else if (endValue == startValue) {
+    stepSize = 0;
+  }
+}
+
+void FieldTransition::step() {
+  callback(field, currentValue);
+  Transition::stepValue(currentValue, endValue, stepSize);
+}
+
+bool FieldTransition::isFinished() {
+  return currentValue == endValue;
+}

--- a/lib/Transitions/FieldTransition.cpp
+++ b/lib/Transitions/FieldTransition.cpp
@@ -31,7 +31,6 @@ std::shared_ptr<Transition> FieldTransition::Builder::_build() const {
     start,
     end,
     stepSize,
-    duration,
     period,
     callback
   );
@@ -44,7 +43,6 @@ FieldTransition::FieldTransition(
   uint16_t startValue,
   uint16_t endValue,
   int16_t stepSize,
-  size_t duration,
   size_t period,
   TransitionFn callback
 ) : Transition(id, bulbId, period, callback)

--- a/lib/Transitions/FieldTransition.h
+++ b/lib/Transitions/FieldTransition.h
@@ -30,7 +30,6 @@ public:
     uint16_t startValue,
     uint16_t endValue,
     int16_t stepSize,
-    size_t duration,
     size_t period,
     TransitionFn callback
   );

--- a/lib/Transitions/FieldTransition.h
+++ b/lib/Transitions/FieldTransition.h
@@ -41,6 +41,7 @@ private:
   int16_t currentValue;
   const int16_t endValue;
   const int16_t stepSize;
+  bool finished;
 
   virtual void step() override;
   virtual void childSerialize(JsonObject& json) override;

--- a/lib/Transitions/FieldTransition.h
+++ b/lib/Transitions/FieldTransition.h
@@ -11,6 +11,7 @@ class FieldTransition : public Transition {
 public:
   FieldTransition(
     size_t id,
+    const BulbId& bulbId,
     GroupStateField field,
     uint16_t startValue,
     uint16_t endValue,
@@ -27,4 +28,5 @@ private:
   const int16_t endValue;
 
   virtual void step() override;
+  virtual void childSerialize(JsonObject& json) override;
 };

--- a/lib/Transitions/FieldTransition.h
+++ b/lib/Transitions/FieldTransition.h
@@ -9,14 +9,29 @@
 
 class FieldTransition : public Transition {
 public:
+
+  class Builder : public Transition::Builder {
+  public:
+    Builder(size_t id, const BulbId& bulbId, TransitionFn callback, GroupStateField field, uint16_t start, uint16_t end);
+
+    virtual std::shared_ptr<Transition> _build() const override;
+
+  private:
+    size_t stepSize;
+    GroupStateField field;
+    uint16_t start;
+    uint16_t end;
+  };
+
   FieldTransition(
     size_t id,
     const BulbId& bulbId,
     GroupStateField field,
     uint16_t startValue,
     uint16_t endValue,
-    uint16_t stepSize,
+    int16_t stepSize,
     size_t duration,
+    size_t period,
     TransitionFn callback
   );
 
@@ -26,6 +41,7 @@ private:
   const GroupStateField field;
   int16_t currentValue;
   const int16_t endValue;
+  const int16_t stepSize;
 
   virtual void step() override;
   virtual void childSerialize(JsonObject& json) override;

--- a/lib/Transitions/FieldTransition.h
+++ b/lib/Transitions/FieldTransition.h
@@ -1,0 +1,30 @@
+#include <GroupStateField.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <Arduino.h>
+#include <functional>
+#include <Transition.h>
+
+#pragma once
+
+class FieldTransition : public Transition {
+public:
+  FieldTransition(
+    size_t id,
+    GroupStateField field,
+    uint16_t startValue,
+    uint16_t endValue,
+    uint16_t stepSize,
+    size_t duration,
+    TransitionFn callback
+  );
+
+  virtual bool isFinished() override;
+
+private:
+  const GroupStateField field;
+  int16_t currentValue;
+  const int16_t endValue;
+
+  virtual void step() override;
+};

--- a/lib/Transitions/Transition.cpp
+++ b/lib/Transitions/Transition.cpp
@@ -11,8 +11,8 @@ Transition::Builder::Builder(size_t id, const BulbId& bulbId, TransitionFn callb
   , numPeriods(0)
 { }
 
-Transition::Builder& Transition::Builder::setDuration(size_t duration) {
-  this->duration = duration;
+Transition::Builder& Transition::Builder::setDuration(float duration) {
+  this->duration = duration * DURATION_UNIT_MULTIPLIER;
   return *this;
 }
 

--- a/lib/Transitions/Transition.cpp
+++ b/lib/Transitions/Transition.cpp
@@ -50,5 +50,9 @@ void Transition::serialize(JsonObject& json) {
   json["id"] = id;
   json["period"] = period;
   json["last_sent"] = lastSent;
+
+  JsonObject bulbParams = json.createNestedObject("bulb");
+  bulbId.serialize(bulbParams);
+
   childSerialize(json);
 }

--- a/lib/Transitions/Transition.cpp
+++ b/lib/Transitions/Transition.cpp
@@ -1,0 +1,45 @@
+#include <Transition.h>
+#include <Arduino.h>
+#include <cmath>
+
+Transition::Transition(
+  size_t id,
+  uint16_t stepSize,
+  size_t period,
+  TransitionFn callback
+) : id(id)
+  , stepSize(stepSize)
+  , period(period)
+  , callback(callback)
+  , lastSent(0)
+{ }
+
+void Transition::tick() {
+  unsigned long now = millis();
+
+  if ((lastSent + period) <= now
+    && ((!isFinished() || lastSent == 0))) { // always send at least once
+
+    step();
+    lastSent = now;
+  }
+}
+
+size_t Transition::calculatePeriod(int16_t distance, size_t stepSize, size_t duration) {
+  float fPeriod =
+    distance != 0
+      ? (duration / (distance / static_cast<float>(stepSize)))
+      : 0;
+
+  return static_cast<size_t>(round(fPeriod));
+}
+
+
+void Transition::stepValue(int16_t& current, int16_t end, int16_t stepSize) {
+  int16_t delta = end - current;
+  if (std::abs(delta) < std::abs(stepSize)) {
+    current += delta;
+  } else {
+    current += stepSize;
+  }
+}

--- a/lib/Transitions/Transition.cpp
+++ b/lib/Transitions/Transition.cpp
@@ -2,15 +2,107 @@
 #include <Arduino.h>
 #include <cmath>
 
+Transition::Builder::Builder(size_t id, const BulbId& bulbId, TransitionFn callback)
+  : id(id)
+  , bulbId(bulbId)
+  , callback(callback)
+  , duration(0)
+  , period(0)
+  , numPeriods(0)
+{ }
+
+Transition::Builder& Transition::Builder::setDuration(size_t duration) {
+  this->duration = duration;
+  return *this;
+}
+
+Transition::Builder& Transition::Builder::setPeriod(size_t period) {
+  this->period = period;
+  return *this;
+}
+
+Transition::Builder& Transition::Builder::setNumPeriods(size_t numPeriods) {
+  this->numPeriods = numPeriods;
+  return *this;
+}
+
+bool Transition::Builder::isSetDuration() const {
+  return this->duration > 0;
+}
+
+bool Transition::Builder::isSetPeriod() const {
+  return this->period > 0;
+}
+
+bool Transition::Builder::isSetNumPeriods() const {
+  return this->numPeriods > 0;
+}
+
+size_t Transition::Builder::numSetParams() const {
+  size_t setCount = 0;
+
+  if (isSetDuration()) { ++setCount; }
+  if (isSetPeriod()) { ++setCount; }
+  if (isSetNumPeriods()) { ++setCount; }
+
+  return setCount;
+}
+
+size_t Transition::Builder::getOrComputePeriod() const {
+  if (period > 0) {
+    return period;
+  } else if (duration > 0 && numPeriods > 0) {
+    return floor(duration / static_cast<float>(numPeriods));
+  } else {
+    return 0;
+  }
+}
+
+size_t Transition::Builder::getOrComputeDuration() const {
+  if (duration > 0) {
+    return duration;
+  } else if (period > 0 && numPeriods > 0) {
+    return period * numPeriods;
+  } else {
+    return 0;
+  }
+}
+
+size_t Transition::Builder::getOrComputeNumPeriods() const {
+  if (numPeriods > 0) {
+    return numPeriods;
+  } else if (period > 0 && duration > 0) {
+    return ceil(duration / static_cast<float>(period));
+  } else {
+    return 0;
+  }
+}
+
+std::shared_ptr<Transition> Transition::Builder::build() {
+  // Set defaults for underspecified transitions
+  size_t numSet = numSetParams();
+
+  if (numSet == 0) {
+    setPeriod(DEFAULT_PERIOD);
+    setNumPeriods(DEFAULT_NUM_PERIODS);
+  } else if (numSet == 1) {
+    if (isSetDuration() || isSetNumPeriods()) {
+      setPeriod(DEFAULT_PERIOD);
+    } else if (isSetPeriod()) {
+      setNumPeriods(DEFAULT_NUM_PERIODS);
+    }
+  }
+
+  return _build();
+}
+
 Transition::Transition(
   size_t id,
   const BulbId& bulbId,
-  uint16_t stepSize,
   size_t period,
   TransitionFn callback
 ) : id(id)
   , bulbId(bulbId)
-  , stepSize(stepSize)
   , period(period)
   , callback(callback)
   , lastSent(0)
@@ -35,7 +127,6 @@ size_t Transition::calculatePeriod(int16_t distance, size_t stepSize, size_t dur
 
   return static_cast<size_t>(round(fPeriod));
 }
-
 
 void Transition::stepValue(int16_t& current, int16_t end, int16_t stepSize) {
   int16_t delta = end - current;

--- a/lib/Transitions/Transition.cpp
+++ b/lib/Transitions/Transition.cpp
@@ -138,9 +138,9 @@ void Transition::stepValue(int16_t& current, int16_t end, int16_t stepSize) {
 }
 
 void Transition::serialize(JsonObject& json) {
-  json["id"] = id;
-  json["period"] = period;
-  json["last_sent"] = lastSent;
+  json[F("id")] = id;
+  json[F("period")] = period;
+  json[F("last_sent")] = lastSent;
 
   JsonObject bulbParams = json.createNestedObject("bulb");
   bulbId.serialize(bulbParams);

--- a/lib/Transitions/Transition.cpp
+++ b/lib/Transitions/Transition.cpp
@@ -4,10 +4,12 @@
 
 Transition::Transition(
   size_t id,
+  const BulbId& bulbId,
   uint16_t stepSize,
   size_t period,
   TransitionFn callback
 ) : id(id)
+  , bulbId(bulbId)
   , stepSize(stepSize)
   , period(period)
   , callback(callback)
@@ -42,4 +44,11 @@ void Transition::stepValue(int16_t& current, int16_t end, int16_t stepSize) {
   } else {
     current += stepSize;
   }
+}
+
+void Transition::serialize(JsonObject& json) {
+  json["id"] = id;
+  json["period"] = period;
+  json["last_sent"] = lastSent;
+  childSerialize(json);
 }

--- a/lib/Transitions/Transition.h
+++ b/lib/Transitions/Transition.h
@@ -12,11 +12,15 @@ class Transition {
 public:
   using TransitionFn = std::function<void(const BulbId& bulbId, GroupStateField field, uint16_t value)>;
 
+  // transition commands are in seconds, convert to ms.
+  static const uint16_t DURATION_UNIT_MULTIPLIER = 1000;
+
+
   class Builder {
   public:
     Builder(size_t id, const BulbId& bulbId, TransitionFn callback);
 
-    Builder& setDuration(size_t duration);
+    Builder& setDuration(float duration);
     Builder& setPeriod(size_t duration);
     Builder& setNumPeriods(size_t numPeriods);
 

--- a/lib/Transitions/Transition.h
+++ b/lib/Transitions/Transition.h
@@ -1,0 +1,35 @@
+#include <GroupStateField.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <functional>
+
+#pragma once
+
+class Transition {
+public:
+  static const size_t DEFAULT_STEP_SIZE = 1;
+
+  using TransitionFn = std::function<void(GroupStateField field, uint16_t value)>;
+
+  Transition(
+    size_t id,
+    uint16_t stepSize,
+    size_t period,
+    TransitionFn callback
+  );
+
+  void tick();
+  virtual bool isFinished() = 0;
+
+  static size_t calculatePeriod(int16_t distance, size_t stepSize, size_t duration);
+
+protected:
+  const size_t id;
+  const int16_t stepSize;
+  const size_t period;
+  const TransitionFn callback;
+  unsigned long lastSent;
+
+  virtual void step() = 0;
+  static void stepValue(int16_t& current, int16_t end, int16_t stepSize);
+};

--- a/lib/Transitions/Transition.h
+++ b/lib/Transitions/Transition.h
@@ -1,3 +1,5 @@
+#include <BulbId.h>
+#include <ArduinoJson.h>
 #include <GroupStateField.h>
 #include <stdint.h>
 #include <stddef.h>
@@ -9,10 +11,13 @@ class Transition {
 public:
   static const size_t DEFAULT_STEP_SIZE = 1;
 
-  using TransitionFn = std::function<void(GroupStateField field, uint16_t value)>;
+  using TransitionFn = std::function<void(const BulbId& bulbId, GroupStateField field, uint16_t value)>;
+  const size_t id;
+  const BulbId bulbId;
 
   Transition(
     size_t id,
+    const BulbId& bulbId,
     uint16_t stepSize,
     size_t period,
     TransitionFn callback
@@ -20,16 +25,17 @@ public:
 
   void tick();
   virtual bool isFinished() = 0;
+  void serialize(JsonObject& doc);
 
   static size_t calculatePeriod(int16_t distance, size_t stepSize, size_t duration);
 
 protected:
-  const size_t id;
   const int16_t stepSize;
   const size_t period;
   const TransitionFn callback;
   unsigned long lastSent;
 
   virtual void step() = 0;
+  virtual void childSerialize(JsonObject& doc) = 0;
   static void stepValue(int16_t& current, int16_t end, int16_t stepSize);
 };

--- a/lib/Transitions/Transition.h
+++ b/lib/Transitions/Transition.h
@@ -4,21 +4,58 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <functional>
+#include <memory>
 
 #pragma once
 
 class Transition {
 public:
-  static const size_t DEFAULT_STEP_SIZE = 1;
-
   using TransitionFn = std::function<void(const BulbId& bulbId, GroupStateField field, uint16_t value)>;
+
+  class Builder {
+  public:
+    Builder(size_t id, const BulbId& bulbId, TransitionFn callback);
+
+    Builder& setDuration(size_t duration);
+    Builder& setPeriod(size_t duration);
+    Builder& setNumPeriods(size_t numPeriods);
+
+    bool isSetDuration() const;
+    bool isSetPeriod() const;
+    bool isSetNumPeriods() const;
+
+    size_t getOrComputePeriod() const;
+    size_t getOrComputeDuration() const;
+    size_t getOrComputeNumPeriods() const;
+
+    std::shared_ptr<Transition> build();
+
+  protected:
+    size_t id;
+    const BulbId& bulbId;
+    TransitionFn callback;
+
+  private:
+    size_t duration;
+    size_t period;
+    size_t numPeriods;
+
+    virtual std::shared_ptr<Transition> _build() const = 0;
+    size_t numSetParams() const;
+  };
+
+  // Default time to wait between steps.  Do this rather than having a fixed step size because it's
+  // more capable of adapting to different situations.
+  static const size_t DEFAULT_PERIOD = 300;
+  static const size_t DEFAULT_NUM_PERIODS = 20; // works out to a duration of 6s
+  static const size_t DEFAULT_DURATION = 6000;
+
   const size_t id;
   const BulbId bulbId;
 
   Transition(
     size_t id,
     const BulbId& bulbId,
-    uint16_t stepSize,
     size_t period,
     TransitionFn callback
   );
@@ -30,7 +67,6 @@ public:
   static size_t calculatePeriod(int16_t distance, size_t stepSize, size_t duration);
 
 protected:
-  const int16_t stepSize;
   const size_t period;
   const TransitionFn callback;
   unsigned long lastSent;

--- a/lib/Transitions/Transition.h
+++ b/lib/Transitions/Transition.h
@@ -21,7 +21,7 @@ public:
     Builder(size_t id, const BulbId& bulbId, TransitionFn callback);
 
     Builder& setDuration(float duration);
-    Builder& setPeriod(size_t duration);
+    Builder& setPeriod(size_t period);
     Builder& setNumPeriods(size_t numPeriods);
 
     bool isSetDuration() const;

--- a/lib/Transitions/TransitionController.cpp
+++ b/lib/Transitions/TransitionController.cpp
@@ -1,0 +1,87 @@
+#include <Transition.h>
+#include <FieldTransition.h>
+#include <ColorTransition.h>
+#include <GroupStateField.h>
+
+#include <TransitionController.h>
+#include <LinkedList.h>
+#include <functional>
+
+using namespace std::placeholders;
+
+TransitionController::TransitionController()
+  : currentId(0)
+{ }
+
+void TransitionController::clearListeners() {
+  observers.clear();
+}
+
+void TransitionController::addListener(Transition::TransitionFn fn) {
+  observers.push_back(fn);
+}
+
+void TransitionController::scheduleTransition(
+  GroupStateField field,
+  uint16_t startValue,
+  uint16_t endValue,
+  uint16_t stepSize,
+  size_t duration
+) {
+  activeTransitions.add(
+    std::make_shared<FieldTransition>(
+      currentId++,
+      field,
+      startValue,
+      endValue,
+      stepSize,
+      duration,
+      std::bind(&TransitionController::transitionCallback, this, _1, _2)
+    )
+  );
+}
+
+void TransitionController::scheduleTransition(
+  const ParsedColor& startColor,
+  const ParsedColor& endColor,
+  uint16_t stepSize,
+  size_t duration
+) {
+  activeTransitions.add(
+    std::make_shared<ColorTransition>(
+      currentId++,
+      startColor,
+      endColor,
+      stepSize,
+      duration,
+      std::bind(&TransitionController::transitionCallback, this, _1, _2)
+    )
+  );
+}
+
+void TransitionController::transitionCallback(GroupStateField field, uint16_t arg) {
+  for (auto it = observers.begin(); it != observers.end(); ++it) {
+    (*it)(field, arg);
+  }
+}
+
+void TransitionController::clear() {
+  activeTransitions.clear();
+}
+
+void TransitionController::loop() {
+  auto current = activeTransitions.getHead();
+
+  while (current != nullptr) {
+    auto next = current->next;
+
+    Transition& t = *current->data;
+    t.tick();
+
+    if (t.isFinished()) {
+      activeTransitions.remove(current);
+    }
+
+    current = next;
+  }
+}

--- a/lib/Transitions/TransitionController.h
+++ b/lib/Transitions/TransitionController.h
@@ -13,21 +13,11 @@ public:
 
   void clearListeners();
   void addListener(Transition::TransitionFn fn);
-  void scheduleTransition(
-    const BulbId& bulbId,
-    GroupStateField field,
-    uint16_t startValue,
-    uint16_t endValue,
-    uint16_t stepSize,
-    size_t duration
-  );
-  void scheduleTransition(
-    const BulbId& bulbId,
-    const ParsedColor& startColor,
-    const ParsedColor& endColor,
-    uint16_t stepSize,
-    size_t duration
-  );
+
+  std::shared_ptr<Transition::Builder> buildColorTransition(const BulbId& bulbId, const ParsedColor& start, const ParsedColor& end);
+  std::shared_ptr<Transition::Builder> buildFieldTransition(const BulbId& bulbId, GroupStateField field, uint16_t start, uint16_t end);
+
+  void addTransition(std::shared_ptr<Transition> transition);
   void clear();
   void loop();
 
@@ -37,6 +27,7 @@ public:
   bool deleteTransition(size_t id);
 
 private:
+  Transition::TransitionFn callback;
   LinkedList<std::shared_ptr<Transition>> activeTransitions;
   std::vector<Transition::TransitionFn> observers;
   size_t currentId;

--- a/lib/Transitions/TransitionController.h
+++ b/lib/Transitions/TransitionController.h
@@ -1,0 +1,38 @@
+#include <Transition.h>
+#include <LinkedList.h>
+#include <ParsedColor.h>
+#include <GroupStateField.h>
+#include <memory>
+#include <vector>
+
+#pragma once
+
+class TransitionController {
+public:
+  TransitionController();
+
+  void clearListeners();
+  void addListener(Transition::TransitionFn fn);
+  void scheduleTransition(
+    GroupStateField field,
+    uint16_t startValue,
+    uint16_t endValue,
+    uint16_t stepSize,
+    size_t duration
+  );
+  void scheduleTransition(
+    const ParsedColor& startColor,
+    const ParsedColor& endColor,
+    uint16_t stepSize,
+    size_t duration
+  );
+  void clear();
+  void loop();
+
+private:
+  LinkedList<std::shared_ptr<Transition>> activeTransitions;
+  std::vector<Transition::TransitionFn> observers;
+  size_t currentId;
+
+  void transitionCallback(GroupStateField field, uint16_t arg);
+};

--- a/lib/Transitions/TransitionController.h
+++ b/lib/Transitions/TransitionController.h
@@ -14,6 +14,7 @@ public:
   void clearListeners();
   void addListener(Transition::TransitionFn fn);
   void scheduleTransition(
+    const BulbId& bulbId,
     GroupStateField field,
     uint16_t startValue,
     uint16_t endValue,
@@ -21,6 +22,7 @@ public:
     size_t duration
   );
   void scheduleTransition(
+    const BulbId& bulbId,
     const ParsedColor& startColor,
     const ParsedColor& endColor,
     uint16_t stepSize,
@@ -29,10 +31,15 @@ public:
   void clear();
   void loop();
 
+  ListNode<std::shared_ptr<Transition>>* getTransitions();
+  Transition* getTransition(size_t id);
+  ListNode<std::shared_ptr<Transition>>* findTransition(size_t id);
+  bool deleteTransition(size_t id);
+
 private:
   LinkedList<std::shared_ptr<Transition>> activeTransitions;
   std::vector<Transition::TransitionFn> observers;
   size_t currentId;
 
-  void transitionCallback(GroupStateField field, uint16_t arg);
+  void transitionCallback(const BulbId& bulbId, GroupStateField field, uint16_t arg);
 };

--- a/lib/Types/BulbId.cpp
+++ b/lib/Types/BulbId.cpp
@@ -1,4 +1,5 @@
 #include <BulbId.h>
+#include <GroupStateField.h>
 
 BulbId::BulbId()
   : deviceId(0),

--- a/lib/Types/BulbId.cpp
+++ b/lib/Types/BulbId.cpp
@@ -47,7 +47,7 @@ String BulbId::getHexDeviceId() const {
 }
 
 void BulbId::serialize(JsonObject json) const {
-  json["device_id"] = deviceId;
-  json["group_id"] = groupId;
-  json["device_type"] = MiLightRemoteTypeHelpers::remoteTypeToString(deviceType);
+  json[GroupStateFieldNames::DEVICE_ID] = deviceId;
+  json[GroupStateFieldNames::GROUP_ID] = groupId;
+  json[GroupStateFieldNames::DEVICE_TYPE] = MiLightRemoteTypeHelpers::remoteTypeToString(deviceType);
 }

--- a/lib/Types/BulbId.cpp
+++ b/lib/Types/BulbId.cpp
@@ -45,3 +45,9 @@ String BulbId::getHexDeviceId() const {
   sprintf_P(hexDeviceId, PSTR("0x%X"), deviceId);
   return hexDeviceId;
 }
+
+void BulbId::serialize(JsonObject json) const {
+  json["device_id"] = deviceId;
+  json["group_id"] = groupId;
+  json["device_type"] = MiLightRemoteTypeHelpers::remoteTypeToString(deviceType);
+}

--- a/lib/Types/BulbId.h
+++ b/lib/Types/BulbId.h
@@ -2,6 +2,7 @@
 
 #include <stdint.h>
 #include <MiLightRemoteType.h>
+#include <ArduinoJson.h>
 
 struct BulbId {
   uint16_t deviceId;
@@ -16,4 +17,5 @@ struct BulbId {
 
   uint32_t getCompactId() const;
   String getHexDeviceId() const;
+  void serialize(JsonObject json) const;
 };

--- a/lib/Types/GroupStateField.cpp
+++ b/lib/Types/GroupStateField.cpp
@@ -2,24 +2,24 @@
 #include <Size.h>
 
 static const char* STATE_NAMES[] = {
-  "unknown",
-  "state",
-  "status",
-  "brightness",
-  "level",
-  "hue",
-  "saturation",
-  "color",
-  "mode",
-  "kelvin",
-  "color_temp",
-  "bulb_mode",
-  "computed_color",
-  "effect",
-  "device_id",
-  "group_id",
-  "device_type",
-  "oh_color"
+  GroupStateFieldNames::UNKNOWN,
+  GroupStateFieldNames::STATE,
+  GroupStateFieldNames::STATUS,
+  GroupStateFieldNames::BRIGHTNESS,
+  GroupStateFieldNames::LEVEL,
+  GroupStateFieldNames::HUE,
+  GroupStateFieldNames::SATURATION,
+  GroupStateFieldNames::COLOR,
+  GroupStateFieldNames::MODE,
+  GroupStateFieldNames::KELVIN,
+  GroupStateFieldNames::COLOR_TEMP,
+  GroupStateFieldNames::BULB_MODE,
+  GroupStateFieldNames::COMPUTED_COLOR,
+  GroupStateFieldNames::EFFECT,
+  GroupStateFieldNames::DEVICE_ID,
+  GroupStateFieldNames::GROUP_ID,
+  GroupStateFieldNames::DEVICE_TYPE,
+  GroupStateFieldNames::OH_COLOR
 };
 
 GroupStateField GroupStateFieldHelpers::getFieldByName(const char* name) {

--- a/lib/Types/GroupStateField.h
+++ b/lib/Types/GroupStateField.h
@@ -12,6 +12,7 @@ namespace GroupStateFieldNames {
   static const char COLOR[] = "color";
   static const char MODE[] = "mode";
   static const char KELVIN[] = "kelvin";
+  static const char TEMPERATURE[] = "temperature"; //alias for kelvin
   static const char COLOR_TEMP[] = "color_temp";
   static const char BULB_MODE[] = "bulb_mode";
   static const char COMPUTED_COLOR[] = "computed_color";
@@ -20,6 +21,8 @@ namespace GroupStateFieldNames {
   static const char GROUP_ID[] = "group_id";
   static const char DEVICE_TYPE[] = "device_type";
   static const char OH_COLOR[] = "oh_color";
+  static const char COMMAND[] = "command";
+  static const char COMMANDS[] = "commands";
 };
 
 enum class GroupStateField {

--- a/lib/Types/GroupStateField.h
+++ b/lib/Types/GroupStateField.h
@@ -1,6 +1,27 @@
 #ifndef _GROUP_STATE_FIELDS_H
 #define _GROUP_STATE_FIELDS_H
 
+namespace GroupStateFieldNames {
+  static const char UNKNOWN[] = "unknown";
+  static const char STATE[] = "state";
+  static const char STATUS[] = "status";
+  static const char BRIGHTNESS[] = "brightness";
+  static const char LEVEL[] = "level";
+  static const char HUE[] = "hue";
+  static const char SATURATION[] = "saturation";
+  static const char COLOR[] = "color";
+  static const char MODE[] = "mode";
+  static const char KELVIN[] = "kelvin";
+  static const char COLOR_TEMP[] = "color_temp";
+  static const char BULB_MODE[] = "bulb_mode";
+  static const char COMPUTED_COLOR[] = "computed_color";
+  static const char EFFECT[] = "effect";
+  static const char DEVICE_ID[] = "device_id";
+  static const char GROUP_ID[] = "group_id";
+  static const char DEVICE_TYPE[] = "device_type";
+  static const char OH_COLOR[] = "oh_color";
+};
+
 enum class GroupStateField {
   UNKNOWN,
   STATE,

--- a/lib/Types/MiLightCommands.h
+++ b/lib/Types/MiLightCommands.h
@@ -1,0 +1,18 @@
+#pragma once
+
+namespace MiLightCommandNames {
+  static const char UNPAIR[] = "unpair";
+  static const char PAIR[] = "pair";
+  static const char SET_WHITE[] = "set_white";
+  static const char NIGHT_MODE[] = "night_mode";
+  static const char LEVEL_UP[] = "level_up";
+  static const char LEVEL_DOWN[] = "level_down";
+  static const char TEMPERATURE_UP[] = "temperature_up";
+  static const char TEMPERATURE_DOWN[] = "temperature_down";
+  static const char NEXT_MODE[] = "next_mode";
+  static const char PREVIOUS_MODE[] = "previous_mode";
+  static const char MODE_SPEED_DOWN[] = "mode_speed_down";
+  static const char MODE_SPEED_UP[] = "mode_speed_up";
+  static const char TOGGLE[] = "toggle";
+  static const char TRANSITION[] = "transition";
+};

--- a/lib/Types/ParsedColor.cpp
+++ b/lib/Types/ParsedColor.cpp
@@ -24,7 +24,7 @@ ParsedColor ParsedColor::fromJson(JsonVariant json) {
   uint16_t r, g, b;
 
   if (json.is<JsonObject>()) {
-    JsonObject color = json["color"];
+    JsonObject color = json[GroupStateFieldNames::COLOR];
 
     r = color["r"];
     g = color["g"];

--- a/lib/Types/ParsedColor.cpp
+++ b/lib/Types/ParsedColor.cpp
@@ -1,6 +1,7 @@
 #include <ParsedColor.h>
 #include <RGBConverter.h>
 #include <TokenIterator.h>
+#include <GroupStateField.h>
 
 ParsedColor ParsedColor::fromRgb(uint16_t r, uint16_t g, uint16_t b) {
   double hsv[3];

--- a/lib/Types/ParsedColor.cpp
+++ b/lib/Types/ParsedColor.cpp
@@ -1,0 +1,55 @@
+#include <ParsedColor.h>
+#include <RGBConverter.h>
+#include <TokenIterator.h>
+
+ParsedColor ParsedColor::fromRgb(uint16_t r, uint16_t g, uint16_t b) {
+  double hsv[3];
+  RGBConverter converter;
+  converter.rgbToHsv(r, g, b, hsv);
+
+  uint16_t hue = round(hsv[0]*360);
+  uint8_t saturation = round(hsv[1]*100);
+
+  return ParsedColor{
+    .success = true,
+    .hue = hue,
+    .r = r,
+    .g = g,
+    .b = b,
+    .saturation = saturation
+  };
+}
+
+ParsedColor ParsedColor::fromJson(JsonVariant json) {
+  uint16_t r, g, b;
+
+  if (json.is<JsonObject>()) {
+    JsonObject color = json["color"];
+
+    r = color["r"];
+    g = color["g"];
+    b = color["b"];
+  } else if (json.is<const char*>()) {
+    const char* colorStr = json.as<const char*>();
+    const size_t len = strlen(colorStr);
+
+    char colorCStr[len+1];
+    uint8_t parsedRgbColors[3] = {0, 0, 0};
+
+    strcpy(colorCStr, colorStr);
+    TokenIterator colorValueItr(colorCStr, len, ',');
+
+    for (size_t i = 0; i < 3 && colorValueItr.hasNext(); ++i) {
+      parsedRgbColors[i] = atoi(colorValueItr.nextToken());
+    }
+
+    r = parsedRgbColors[0];
+    g = parsedRgbColors[1];
+    b = parsedRgbColors[2];
+  } else {
+    Serial.println(F("GroupState::parseJsonColor - unknown format for color"));
+    return ParsedColor{ .success = false };
+  }
+
+  return ParsedColor::fromRgb(r, g, b);
+}

--- a/lib/Types/ParsedColor.cpp
+++ b/lib/Types/ParsedColor.cpp
@@ -25,7 +25,7 @@ ParsedColor ParsedColor::fromJson(JsonVariant json) {
   uint16_t r, g, b;
 
   if (json.is<JsonObject>()) {
-    JsonObject color = json[GroupStateFieldNames::COLOR];
+    JsonObject color = json.as<JsonObject>();
 
     r = color["r"];
     g = color["g"];

--- a/lib/Types/ParsedColor.h
+++ b/lib/Types/ParsedColor.h
@@ -1,0 +1,13 @@
+#include <stdint.h>
+#include <ArduinoJson.h>
+
+#pragma once
+
+struct ParsedColor {
+  bool success;
+  uint16_t hue, r, g, b;
+  uint8_t saturation;
+
+  static ParsedColor fromRgb(uint16_t r, uint16_t g, uint16_t b);
+  static ParsedColor fromJson(JsonVariant json);
+};

--- a/lib/WebServer/MiLightHttpServer.cpp
+++ b/lib/WebServer/MiLightHttpServer.cpp
@@ -639,7 +639,7 @@ void MiLightHttpServer::handleCreateTransition(RequestContext& request) {
     sprintf_P(buffer, PSTR("Must specify required keys: device_id, group_id, remote_type"));
 
     request.response.setCode(400);
-    request.response.json["error"] = buffer;
+    request.response.json[F("error")] = buffer;
     return;
   }
 
@@ -647,11 +647,11 @@ void MiLightHttpServer::handleCreateTransition(RequestContext& request) {
   uint8_t _groupId = atoi(body[GroupStateFieldNames::GROUP_ID]);
   const MiLightRemoteConfig* _remoteType = MiLightRemoteConfig::fromType(body[F("remote_type")].as<const char*>());
 
-  if (_remoteType == NULL) {
+  if (_remoteType == nullptr) {
     char buffer[40];
     sprintf_P(buffer, PSTR("Unknown device type\n"));
     request.response.setCode(400);
-    request.response.json["error"] = buffer;
+    request.response.json[F("error")] = buffer;
     return;
   }
 

--- a/lib/WebServer/MiLightHttpServer.cpp
+++ b/lib/WebServer/MiLightHttpServer.cpp
@@ -624,7 +624,7 @@ void MiLightHttpServer::handleListTransitions(RequestContext& request) {
 
   while (current != nullptr) {
     JsonObject json = transitions.createNestedObject();
-    json["id"] = current->data->id;
+    current->data->serialize(json);
     current = current->next;
   }
 }

--- a/lib/WebServer/MiLightHttpServer.cpp
+++ b/lib/WebServer/MiLightHttpServer.cpp
@@ -656,6 +656,10 @@ void MiLightHttpServer::handleCreateTransition(RequestContext& request) {
   }
 
   milightClient->prepare(_remoteType, parseInt<uint16_t>(_deviceId), _groupId);
-  milightClient->handleTransition(request.getJsonBody().as<JsonObject>());
-  request.response.json[F("success")] = true;
+
+  if (milightClient->handleTransition(request.getJsonBody().as<JsonObject>(), request.response.json)) {
+    request.response.json[F("success")] = true;
+  } else {
+    request.response.setCode(400);
+  }
 }

--- a/lib/WebServer/MiLightHttpServer.cpp
+++ b/lib/WebServer/MiLightHttpServer.cpp
@@ -644,7 +644,7 @@ void MiLightHttpServer::handleCreateTransition(RequestContext& request) {
   }
 
   const String _deviceId = body[GroupStateFieldNames::DEVICE_ID];
-  uint8_t _groupId = atoi(body[GroupStateFieldNames::GROUP_ID]);
+  uint8_t _groupId = body[GroupStateFieldNames::GROUP_ID];
   const MiLightRemoteConfig* _remoteType = MiLightRemoteConfig::fromType(body[F("remote_type")].as<const char*>());
 
   if (_remoteType == nullptr) {

--- a/lib/WebServer/MiLightHttpServer.cpp
+++ b/lib/WebServer/MiLightHttpServer.cpp
@@ -110,8 +110,8 @@ void MiLightHttpServer::handleSystemPost(RequestContext& request) {
 
   bool handled = false;
 
-  if (requestBody.containsKey("command")) {
-    if (requestBody["command"] == "restart") {
+  if (requestBody.containsKey(GroupStateFieldNames::COMMAND)) {
+    if (requestBody[GroupStateFieldNames::COMMAND] == "restart") {
       Serial.println(F("Restarting..."));
       server.send_P(200, TEXT_PLAIN, PSTR("true"));
 
@@ -120,7 +120,7 @@ void MiLightHttpServer::handleSystemPost(RequestContext& request) {
       ESP.restart();
 
       handled = true;
-    } else if (requestBody["command"] == "clear_wifi_config") {
+    } else if (requestBody[GroupStateFieldNames::COMMAND] == "clear_wifi_config") {
         Serial.println(F("Resetting Wifi and then Restarting..."));
         server.send_P(200, TEXT_PLAIN, PSTR("true"));
 

--- a/lib/WebServer/MiLightHttpServer.cpp
+++ b/lib/WebServer/MiLightHttpServer.cpp
@@ -367,8 +367,8 @@ void MiLightHttpServer::handleGetGroupAlias(RequestContext& request) {
 }
 
 void MiLightHttpServer::handleGetGroup(RequestContext& request) {
-  const String _deviceId = request.pathVariables.get("device_id");
-  uint8_t _groupId = atoi(request.pathVariables.get("group_id"));
+  const String _deviceId = request.pathVariables.get(GroupStateFieldNames::DEVICE_ID);
+  uint8_t _groupId = atoi(request.pathVariables.get(GroupStateFieldNames::GROUP_ID));
   const MiLightRemoteConfig* _remoteType = MiLightRemoteConfig::fromType(request.pathVariables.get("type"));
 
   if (_remoteType == NULL) {
@@ -384,8 +384,8 @@ void MiLightHttpServer::handleGetGroup(RequestContext& request) {
 }
 
 void MiLightHttpServer::handleDeleteGroup(RequestContext& request) {
-  const String _deviceId = request.pathVariables.get("device_id");
-  uint8_t _groupId = atoi(request.pathVariables.get("group_id"));
+  const String _deviceId = request.pathVariables.get(GroupStateFieldNames::DEVICE_ID);
+  uint8_t _groupId = atoi(request.pathVariables.get(GroupStateFieldNames::GROUP_ID));
   const MiLightRemoteConfig* _remoteType = MiLightRemoteConfig::fromType(request.pathVariables.get("type"));
 
   if (_remoteType == NULL) {
@@ -454,8 +454,8 @@ void MiLightHttpServer::handleUpdateGroupAlias(RequestContext& request) {
 void MiLightHttpServer::handleUpdateGroup(RequestContext& request) {
   JsonObject reqObj = request.getJsonBody().as<JsonObject>();
 
-  String _deviceIds = request.pathVariables.get("device_id");
-  String _groupIds = request.pathVariables.get("group_id");
+  String _deviceIds = request.pathVariables.get(GroupStateFieldNames::DEVICE_ID);
+  String _groupIds = request.pathVariables.get(GroupStateFieldNames::GROUP_ID);
   String _remoteTypes = request.pathVariables.get("type");
   char deviceIds[_deviceIds.length()];
   char groupIds[_groupIds.length()];
@@ -632,8 +632,8 @@ void MiLightHttpServer::handleListTransitions(RequestContext& request) {
 void MiLightHttpServer::handleCreateTransition(RequestContext& request) {
   JsonObject body = request.getJsonBody().as<JsonObject>();
 
-  if (! body.containsKey(F("device_id"))
-    || ! body.containsKey(F("group_id"))
+  if (! body.containsKey(GroupStateFieldNames::DEVICE_ID)
+    || ! body.containsKey(GroupStateFieldNames::GROUP_ID)
     || ! body.containsKey(F("remote_type"))) {
     char buffer[200];
     sprintf_P(buffer, PSTR("Must specify required keys: device_id, group_id, remote_type"));
@@ -643,8 +643,8 @@ void MiLightHttpServer::handleCreateTransition(RequestContext& request) {
     return;
   }
 
-  const String _deviceId = body[F("device_id")];
-  uint8_t _groupId = atoi(body[F("group_id")]);
+  const String _deviceId = body[GroupStateFieldNames::DEVICE_ID];
+  uint8_t _groupId = atoi(body[GroupStateFieldNames::GROUP_ID]);
   const MiLightRemoteConfig* _remoteType = MiLightRemoteConfig::fromType(body[F("remote_type")].as<const char*>());
 
   if (_remoteType == NULL) {

--- a/lib/WebServer/MiLightHttpServer.h
+++ b/lib/WebServer/MiLightHttpServer.h
@@ -5,6 +5,7 @@
 #include <GroupStateStore.h>
 #include <RadioSwitchboard.h>
 #include <PacketSender.h>
+#include <TransitionController.h>
 
 #ifndef _MILIGHT_HTTP_SERVER
 #define _MILIGHT_HTTP_SERVER
@@ -27,7 +28,8 @@ public:
     MiLightClient*& milightClient,
     GroupStateStore*& stateStore,
     PacketSender*& packetSender,
-    RadioSwitchboard*& radios
+    RadioSwitchboard*& radios,
+    TransitionController& transitions
   )
     : authProvider(settings)
     , server(80, authProvider)
@@ -38,6 +40,7 @@ public:
     , stateStore(stateStore)
     , packetSender(packetSender)
     , radios(radios)
+    , transitions(transitions)
   { }
 
   void begin();
@@ -79,6 +82,11 @@ protected:
   void handleDeleteGroupAlias(RequestContext& request);
   void _handleDeleteGroup(BulbId bulbId, RequestContext& request);
 
+  void handleGetTransition(RequestContext& request);
+  void handleDeleteTransition(RequestContext& request);
+  void handleCreateTransition(RequestContext& request);
+  void handleListTransitions(RequestContext& request);
+
   void handleRequest(const JsonObject& request);
   void handleWsEvent(uint8_t num, WStype_t type, uint8_t * payload, size_t length);
 
@@ -96,6 +104,7 @@ protected:
   ESP8266WebServer::THandlerFunction _handleRootPage;
   PacketSender*& packetSender;
   RadioSwitchboard*& radios;
+  TransitionController& transitions;
 
 };
 

--- a/test/remote/helpers/mqtt_helpers.rb
+++ b/test/remote/helpers/mqtt_helpers.rb
@@ -25,7 +25,7 @@ module MqttHelpers
       .merge(overrides)
 
     MqttClient.new(
-      params[:mqtt_server],
+      ENV['ESPMH_LOCAL_MQTT_SERVER'] || params[:mqtt_server],
       params[:mqtt_username],
       params[:mqtt_password],
       params[:topic_prefix]

--- a/test/remote/lib/api_client.rb
+++ b/test/remote/lib/api_client.rb
@@ -9,6 +9,13 @@ class ApiClient
     @current_id = Integer(base_id)
   end
 
+  def self.from_environment
+    ApiClient.new(
+      ENV.fetch('ESPMH_HOSTNAME'),
+      ENV.fetch('ESPMH_TEST_DEVICE_ID_BASE')
+    )
+  end
+
   def generate_id
     id = @current_id
     @current_id += 1
@@ -46,7 +53,13 @@ class ApiClient
       end
 
       res = http.request(req)
-      res.value
+
+      begin
+        res.value
+      rescue Exception => e
+        puts "REST Client Error: #{e}\nBody:\n#{res.body}"
+        raise e
+      end
 
       body = res.body
 

--- a/test/remote/lib/api_client.rb
+++ b/test/remote/lib/api_client.rb
@@ -110,4 +110,18 @@ class ApiClient
   def patch_state(state, params = {})
     put(state_path(params), state.to_json)
   end
+
+  def schedule_transition(_id_params, transition_params)
+    id_params = {
+      device_id: _id_params[:id],
+      remote_type: _id_params[:type],
+      group_id: _id_params[:group_id]
+    }
+
+    post("/transitions", id_params.merge(transition_params))
+  end
+
+  def transitions
+    get('/transitions')['transitions']
+  end
 end

--- a/test/remote/spec/mqtt_spec.rb
+++ b/test/remote/spec/mqtt_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'MQTT' do
 
   context 'deleting' do
     it 'should remove retained state' do
-      @client.patch_state(@id_params, status: 'ON')
+      @client.patch_state({status: 'ON'}, @id_params)
 
       seen_blank = false
 

--- a/test/remote/spec/mqtt_spec.rb
+++ b/test/remote/spec/mqtt_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'MQTT' do
 
   context 'client status topic' do
     before(:all) do
-      @status_topic = "#{@topic_prefix}client_status"
+      @status_topic = "#{mqtt_topic_prefix()}client_status"
       @client.patch_settings(mqtt_client_status_topic: @status_topic)
     end
 

--- a/test/remote/spec/settings_spec.rb
+++ b/test/remote/spec/settings_spec.rb
@@ -29,11 +29,11 @@ RSpec.describe 'Settings' do
         'simple_mqtt_client_status' => [true, false],
         'packet_repeats_per_loop' => [10],
         'home_assistant_discovery_prefix' => ['', 'abc', 'a/b/c'],
-        'wifi_force_b_mode' => [true, false]
+        'wifi_mode' => %w(b g n)
       }.each do |key, values|
         values.each do |v|
           @client.patch_settings({key => v})
-          expect(@client.get('/settings')[key]).to eq(v)
+          expect(@client.get('/settings')[key]).to eq(v), "Should persist #{key} possible value: #{v}"
         end
       end
     end

--- a/test/remote/spec/settings_spec.rb
+++ b/test/remote/spec/settings_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe 'Settings' do
 
       end_mem = @client.get('/about')['free_heap']
 
-      expect(end_mem - start_mem).to_not be < -200
+      expect(end_mem).to be > (start_mem - 200)
     end
   end
 

--- a/test/remote/spec/transition_spec.rb
+++ b/test/remote/spec/transition_spec.rb
@@ -1,0 +1,167 @@
+require 'api_client'
+
+RSpec.describe 'Transitions' do
+  before(:all) do
+    @client = ApiClient.from_environment
+    @client.upload_json('/settings', 'settings.json')
+    @transition_params = {
+      field: 'level',
+      start_value: 0,
+      end_value: 100,
+      duration: 2.0,
+      period: 400
+    }
+    @num_transition_updates = (@transition_params[:duration]*1000)/@transition_params[:period]
+  end
+
+  before(:each) do
+    mqtt_params = mqtt_parameters()
+    @updates_topic = mqtt_params[:updates_topic]
+    @topic_prefix = mqtt_topic_prefix()
+
+    @client.put(
+      '/settings',
+      mqtt_params.merge(
+        mqtt_update_topic_pattern: "#{@topic_prefix}updates/:device_id/:device_type/:group_id"
+      )
+    )
+
+    @id_params = {
+      id: @client.generate_id,
+      type: 'rgb_cct',
+      group_id: 1
+    }
+    @client.delete_state(@id_params)
+
+    @mqtt_client = create_mqtt_client()
+
+    # Delete any existing transitions
+    @client.get('/transitions')['transitions'].each do |t|
+      @client.delete("/transitions/#{t['id']}")
+    end
+  end
+
+  context 'REST routes' do
+    it 'should respond with an empty list when there are no transitions' do
+      response = @client.transitions
+      expect(response).to eq([])
+    end
+
+    it 'should respond with an error when missing parameters for POST /transitions' do
+      expect { @client.post('/transitions', {}) }.to raise_error(Net::HTTPServerException)
+    end
+
+    it 'should create a new transition with a valid POST /transitions request' do
+      response = @client.schedule_transition(@id_params, @transition_params)
+
+      expect(response['success']).to eq(true)
+    end
+
+    it 'should list active transitions' do
+      @client.schedule_transition(@id_params, @transition_params)
+
+      response = @client.transitions
+
+      expect(response.length).to be >= 1
+    end
+
+    it 'should support getting an active transition with GET /transitions/:id' do
+      @client.schedule_transition(@id_params, @transition_params)
+
+      response = @client.transitions
+      detail_response = @client.get("/transitions/#{response.last['id']}")
+
+      expect(detail_response['period']).to_not eq(nil)
+    end
+
+    it 'should support deleting active transitions with DELETE /transitions/:id' do
+      @client.schedule_transition(@id_params, @transition_params)
+
+      response = @client.transitions
+
+      response.each do |transition|
+        @client.delete("/transitions/#{transition['id']}")
+      end
+
+      after_delete_response = @client.transitions
+
+      expect(response.length).to eq(1)
+      expect(after_delete_response.length).to eq(0)
+    end
+  end
+
+  context '"transition" key in state update' do
+    it 'should create a new transition' do
+      @client.patch_state(@id_params, {status: 'ON', level: 0})
+      @client.patch_state(@id_params, {level: 100, transition: 2.0})
+
+      response = @client.get('/transitions')
+
+      expect(response.length).to be > 0
+      expect(response.last['type']).to eq('field')
+      expect(response.last['field']).to eq('level')
+      expect(response.last['end_value']).to eq(100)
+
+      @client.delete("/transitions/#{response['id']}")
+    end
+  end
+
+  context 'transition packets' do
+    it 'should send an initial state packet' do
+      seen = false
+
+      @mqtt_client.on_update(@id_params) do |id, message|
+        seen = message['brightness'] == 0
+      end
+
+      @client.schedule_transition(@id_params, @transition_params)
+
+      @mqtt_client.wait_for_listeners
+
+      expect(seen).to be(true)
+    end
+
+    it 'should respect the period parameter' do
+      seen_updates = []
+      update_times = []
+
+      @mqtt_client.on_update(@id_params) do |id, message|
+        seen_updates << message
+        update_times << Time.now
+        message['brightness'] == 255
+      end
+
+      @client.schedule_transition(@id_params, @transition_params.merge(duration: 2.0, period: 500))
+
+      @mqtt_client.wait_for_listeners
+
+      time_gaps = (1...update_times.length).map do |i|
+        update_times[i] - update_times[i-1]
+      end
+
+      expect(seen_updates.length).to eq(4)
+      expect(seen_updates.map { |x| x['brightness'] }).to eq([0, 64, 128, 255])
+      expect(time_gaps).to all( be >= 500 )
+      expect(time_gaps).to all( be <= 510 )
+    end
+
+    it 'should support two transitions for different devices at the same time' do
+      id1 = @id_params
+      id2 = @id_params.merge(type: 'fut089')
+
+      @client.schedule_transition(id1, @transition_params)
+      @client.schedule_transition(id2, @transition_params)
+
+      id1_updates = []
+      id2_updates = []
+
+      @mqtt_client.on_update(id1) { |id, msg| id1_updates << msg }
+      @mqtt_client.on_update(id2) { |id, msg| id2_updates << msg }
+
+      @mqtt_client.wait_for_listeners
+
+      expect(id1_updates.length).to eq(@num_transition_updates)
+      expect(id2_updates.length).to eq(@num_transition_updates)
+    end
+  end
+end

--- a/test/remote/spec/transition_spec.rb
+++ b/test/remote/spec/transition_spec.rb
@@ -195,8 +195,14 @@ RSpec.describe 'Transitions' do
       id1_updates = []
       id2_updates = []
 
-      @mqtt_client.on_update(id1) { |id, msg| id1_updates << msg }
-      @mqtt_client.on_update(id2) { |id, msg| id2_updates << msg }
+      @mqtt_client.on_update do |id, msg|
+        if id[:type] == id1[:type]
+          id1_updates << msg
+        else
+          id2_updates << msg
+        end
+        id1_updates.length == @num_transition_updates && id2_updates.length == @num_transition_updates
+      end
 
       @mqtt_client.wait_for_listeners
 

--- a/test/remote/spec/transition_spec.rb
+++ b/test/remote/spec/transition_spec.rb
@@ -170,11 +170,10 @@ RSpec.describe 'Transitions' do
 
     it 'should respect the period parameter' do
       seen_updates = []
-      update_times = []
+      start_time = Time.now
 
       @mqtt_client.on_update(@id_params) do |id, message|
         seen_updates << message
-        update_times << Time.now
         message['brightness'] == 255
       end
 
@@ -182,14 +181,8 @@ RSpec.describe 'Transitions' do
 
       @mqtt_client.wait_for_listeners
 
-      time_gaps = (1...update_times.length).map do |i|
-        update_times[i] - update_times[i-1]
-      end
-
-      expect(seen_updates.length).to eq(4)
-      expect(seen_updates.map { |x| x['brightness'] }).to eq([0, 64, 128, 255])
-      expect(time_gaps).to all( be >= 500 )
-      expect(time_gaps).to all( be <= 510 )
+      expect(seen_updates.map { |x| x['brightness'] }).to eq([0, 64, 128, 191, 255])
+      expect((Time.now - start_time)/4).to be >= 0.5 # Don't count the first update
     end
 
     it 'should support two transitions for different devices at the same time' do


### PR DESCRIPTION
## Summary of changes:

* Support for transitions (details follow)
* A bunch of miscellaneous cleanups and improvements
* A few bug fixes

## Transitions

This is a weighty feature that enables transitions between states.  For example, you can fade from 100% brightness to 0%, or between two colors.

This can be accomplished either by:

* One of the newly added REST route `/transitions` (details documented in README)
* By adding the `{"transition":x}` key to the state command.  `x` is some the number of seconds you want in-between.

## Bug fixes

* Linked List library had a bug that prevented arbitrary nodes from being deleted
* Use PROGMEM in a couple of new places.  Will marginally improve free heap.
* Fix a test that was broken in 1.10.
* Fix a memory leak that occurred when settings were saved and there is a non-empty state cache.

## Improvements

* Pull string constants like `"brightness"` into actual constants rather than having the literals scattered throughout the codebase.  Prevents typo bugs and decreases heap/flash utilization.
* Refactor main JSON command -> milight packets handler to not use a mess of conditionals.