### PR TITLE
Fix broken build with latest Arduino libs - bump Websockets to ~2.2.0

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -20,7 +20,7 @@ lib_deps_external =
   ArduinoJson@~6.10.1
   PubSubClient@~2.7
   ratkins/RGBConverter@07010f2
-  WebSockets@~2.1.2
+  WebSockets@~2.2.0
   CircularBuffer@~1.2.0
   PathVariableHandlers@~2.0.0
   RichHttpServer@~2.0.2


### PR DESCRIPTION
There was a compilation error when building the external Websockets dependency with latest Arduino libraries (2.5.X).
It was caused by SSL code changes in Arduino and since has been fixed in Websockets 2.2.0.

See Links2004/arduinoWebSockets#447 for details.