### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,9 +276,7 @@ Note that you must restart the hub to affect the change in "enable_solid_led".
 
 You can configure the LED pin from the web console.  Note that pin means the GPIO number, not the D number ... for example, D1 is actually GPIO5 and therefore its pin 5.  If you specify the pin as a negative number, it will invert the LED signal (the built-in LED on pin 2 is inverted, so the default is -2).
 
-If you want to wire up your own LED parallel to the built-in LED you will have to connect it to D4/GPIO2. Put a wire from D4 to one side of a 220 ohm resistor. On the other side, connect it to the positive side (the longer wire) of a 3.3V LED.  Then connect the negative side of the LED (the shorter wire) to ground.  If you use a different voltage LED, or a high current LED, you will need to add a driver circuit.
-
-To use an external LED, use the same instructions above to wire the LED to a GPIO pin of your choosing (D1/GPIO5 is a good choice).
+If you want to wire up your own LED you can connect it to D1/GPIO5. Put a wire from D1 to one side of a 220 ohm resistor. On the other side, connect it to the positive side (the longer wire) of a 3.3V LED.  Then connect the negative side of the LED (the shorter wire) to ground.  If you use a different voltage LED, or a high current LED, you will need to add a driver circuit.
 
 ## Development
 


### PR DESCRIPTION
Testet connecting an LED at the same pin as the internal LED. The external LED will always be inverted against the internal LED. 
So if the internal is off the external is on. So one LED will always be on. This means it's better to use another pin (eg. GPIO5).
So let's go back, sorry. We still changed the example pin, which was connected to CE before.