### PR TITLE
Increased MQTT packet buffer

### DIFF
--- a/lib/MQTT/MqttClient.cpp
+++ b/lib/MQTT/MqttClient.cpp
@@ -59,7 +59,8 @@ bool MqttClient::connect() {
   sprintf_P(nameBuffer, PSTR("milight-hub-%u"), ESP.getChipId());
 
 #ifdef MQTT_DEBUG
-    Serial.println(F("MqttClient - connecting"));
+    Serial.println(F("MqttClient - connecting using name"));
+    Serial.println(nameBuffer);
 #endif
 
   if (settings.mqttUsername.length() > 0 && settings.mqttClientStatusTopic.length() > 0) {
@@ -112,7 +113,8 @@ void MqttClient::reconnect() {
       Serial.println(F("MqttClient - Successfully connected to MQTT server"));
 #endif
     } else {
-      Serial.println(F("ERROR: Failed to connect to MQTT server"));
+      Serial.print(F("ERROR: Failed to connect to MQTT server rc="));
+      Serial.println(mqttClient.state());
     }
   }
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -32,7 +32,7 @@ build_flags =
   !python3 .get_version.py
   # For compatibility with WebSockets 2.1.4 and v2.4 of the Arduino SDK
   -D USING_AXTLS
-  -D MQTT_MAX_PACKET_SIZE=250
+  -D MQTT_MAX_PACKET_SIZE=360
   -D HTTP_UPLOAD_BUFLEN=128
   -D FIRMWARE_NAME=milight-hub
   -D RICH_HTTP_REQUEST_BUFFER_SIZE=2048


### PR DESCRIPTION
With a smaller buffer it's possible that too long last will message will prevent MQTT client from connecting to the MQTT broker. More details in #613.

I also made logging a little verbose, as it was important for me to see MQTT connection rc code.

Closes #613