### PR TITLE
Fix brightness setting command

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -526,7 +526,7 @@ components:
 
         * `night_mode`.  Most devices support a "night mode," which has LEDs turned to a very dim setting -- lower than brightness 0.
 
-        * `level_up`. Turns down the brightness. Not all dimmable bulbs support this command.
+        * `level_up`. Turns up the brightness. Not all dimmable bulbs support this command.
 
         * `level_down`. Turns down the brightness. Not all dimmable bulbs support this command.
 

--- a/lib/MiLight/CctPacketFormatter.cpp
+++ b/lib/MiLight/CctPacketFormatter.cpp
@@ -206,9 +206,9 @@ BulbId CctPacketFormatter::parsePacket(const uint8_t* packet, JsonObject result)
   } else if (onOffGroupId < 255) {
     result[GroupStateFieldNames::STATE] = cctCommandToStatus(command) == ON ? "ON" : "OFF";
   } else if (command == CCT_BRIGHTNESS_DOWN) {
-    result[GroupStateFieldNames::COMMAND] = "brightness_down";
+    result[GroupStateFieldNames::COMMAND] = MiLightCommandNames::LEVEL_DOWN;
   } else if (command == CCT_BRIGHTNESS_UP) {
-    result[GroupStateFieldNames::COMMAND] = "brightness_up";
+    result[GroupStateFieldNames::COMMAND] = MiLightCommandNames::LEVEL_UP;
   } else if (command == CCT_TEMPERATURE_DOWN) {
     result[GroupStateFieldNames::COMMAND] = MiLightCommandNames::TEMPERATURE_DOWN;
   } else if (command == CCT_TEMPERATURE_UP) {

--- a/lib/MiLight/FUT020PacketFormatter.cpp
+++ b/lib/MiLight/FUT020PacketFormatter.cpp
@@ -60,11 +60,11 @@ BulbId FUT020PacketFormatter::parsePacket(const uint8_t* packet, JsonObject resu
       break;
 
     case FUT020Command::BRIGHTNESS_DOWN:
-      result[F("command")] = F("brightness_down");
+      result[F("command")] = F("level_down");
       break;
 
     case FUT020Command::BRIGHTNESS_UP:
-      result[F("command")] = F("brightness_up");
+      result[F("command")] = F("level_up");
       break;
 
     case FUT020Command::MODE_SWITCH:

--- a/lib/MiLight/RgbPacketFormatter.cpp
+++ b/lib/MiLight/RgbPacketFormatter.cpp
@@ -110,9 +110,9 @@ BulbId RgbPacketFormatter::parsePacket(const uint8_t* packet, JsonObject result)
   } else if (command == RGB_SPEED_UP) {
     result[GroupStateFieldNames::COMMAND] = MiLightCommandNames::MODE_SPEED_UP;
   } else if (command == RGB_BRIGHTNESS_DOWN) {
-    result[GroupStateFieldNames::COMMAND] = "brightness_down";
+    result[GroupStateFieldNames::COMMAND] = MiLightCommandNames::LEVEL_DOWN;
   } else if (command == RGB_BRIGHTNESS_UP) {
-    result[GroupStateFieldNames::COMMAND] = "brightness_up";
+    result[GroupStateFieldNames::COMMAND] = MiLightCommandNames::LEVEL_UP;
   } else {
     result["button_id"] = command;
   }

--- a/lib/MiLightState/GroupState.cpp
+++ b/lib/MiLightState/GroupState.cpp
@@ -781,9 +781,9 @@ bool GroupState::patch(JsonObject state) {
       changes |= setBulbMode(BULB_MODE_WHITE);
     } else if (command == MiLightCommandNames::NIGHT_MODE) {
       changes |= setBulbMode(BULB_MODE_NIGHT);
-    } else if (isOn() && command == "brightness_up") {
+    } else if (isOn() && command == MiLightCommandNames::LEVEL_UP) {
       changes |= applyIncrementCommand(GroupStateField::BRIGHTNESS, IncrementDirection::INCREASE);
-    } else if (isOn() && command == "brightness_down") {
+    } else if (isOn() && command == MiLightCommandNames::LEVEL_DOWN) {
       changes |= applyIncrementCommand(GroupStateField::BRIGHTNESS, IncrementDirection::DECREASE);
     } else if (isOn() && command == MiLightCommandNames::TEMPERATURE_UP) {
       changes |= applyIncrementCommand(GroupStateField::KELVIN, IncrementDirection::INCREASE);


### PR DESCRIPTION
I am using espMH with a cct led controller (fut035) and a remote (fut007). I have set Home Assistant to forward messages from the mqtt_update_topic (of the remote) to the mqtt_topic for the emulated cct remote. Set up like this I was able to control the light via the fut007, except the brightness control was not working.
I found that sending `level_up/down` instead of `brightness_up/down` was working.
With this commit my setup is working as expected.