### PR TITLE
Fix color transition memory leak

### DIFF
--- a/lib/Transitions/ColorTransition.cpp
+++ b/lib/Transitions/ColorTransition.cpp
@@ -133,7 +133,7 @@ void ColorTransition::step() {
 }
 
 bool ColorTransition::isFinished() {
-  return finished;
+  return currentColor == endColor; 
 }
 
 void ColorTransition::childSerialize(JsonObject& json) {

--- a/lib/Transitions/ColorTransition.cpp
+++ b/lib/Transitions/ColorTransition.cpp
@@ -73,7 +73,6 @@ ColorTransition::ColorTransition(
   , stepSizes(stepSizes)
   , lastHue(400)         // use impossible values to force a packet send
   , lastSaturation(200)
-  , finished(false)
 {
   int16_t dr = endColor.r - startColor.r
         , dg = endColor.g - startColor.g
@@ -122,10 +121,9 @@ void ColorTransition::step() {
     callback(bulbId, GroupStateField::SATURATION, parsedColor.saturation);
     lastSaturation = parsedColor.saturation;
   }
-
-  if (currentColor == endColor) {
-    finished = true;
-  } else {
+  
+  if(!isFinished())
+  {
     Transition::stepValue(currentColor.r, endColor.r, stepSizes.r);
     Transition::stepValue(currentColor.g, endColor.g, stepSizes.g);
     Transition::stepValue(currentColor.b, endColor.b, stepSizes.b);

--- a/lib/Transitions/ColorTransition.cpp
+++ b/lib/Transitions/ColorTransition.cpp
@@ -122,8 +122,7 @@ void ColorTransition::step() {
     lastSaturation = parsedColor.saturation;
   }
   
-  if(!isFinished())
-  {
+  if (!isFinished()) {
     Transition::stepValue(currentColor.r, endColor.r, stepSizes.r);
     Transition::stepValue(currentColor.g, endColor.g, stepSizes.g);
     Transition::stepValue(currentColor.b, endColor.b, stepSizes.b);

--- a/lib/Transitions/ColorTransition.h
+++ b/lib/Transitions/ColorTransition.h
@@ -51,7 +51,6 @@ protected:
   // Store these to avoid wasted packets
   uint16_t lastHue;
   uint16_t lastSaturation;
-  bool finished;
 
   virtual void step() override;
   virtual void childSerialize(JsonObject& json) override;


### PR DESCRIPTION
Fix for a memory leak which could occur when a light does a color transition to itself.

Example of a transition being stuck:
```
{
  "transitions": [
    {
      "id": 1520,
      "period": 4294967295,
      "last_sent": 0,
      "bulb": {
        "device_id": 1,
        "group_id": 1,
        "device_type": "rgb_cct"
      },
      "type": "color",
      "current_color": [
        255,
        167,
        91
      ],
      "end_color": [
        255,
        167,
        91
      ],
      "step_sizes": [
        0,
        0,
        0
      ]
    },
}
````
 #600 #523 