### PR TITLE
Don't activate every longpress nightmode

### DIFF
--- a/lib/Types/GroupStateField.h
+++ b/lib/Types/GroupStateField.h
@@ -24,6 +24,7 @@ namespace GroupStateFieldNames {
   static const char HEX_COLOR[] = "hex_color";
   static const char COMMAND[] = "command";
   static const char COMMANDS[] = "commands";
+  static const char LONG_PRESS[] = "long_press";
 };
 
 enum class GroupStateField {
@@ -45,7 +46,8 @@ enum class GroupStateField {
   GROUP_ID,
   DEVICE_TYPE,
   OH_COLOR,
-  HEX_COLOR
+  HEX_COLOR,
+  LONG_PRESS
 };
 
 class GroupStateFieldHelpers {


### PR DESCRIPTION
Partially covers #714 .
It will send only night mode on long OFF button press.
It will send on the update channel "long_press" with true/false when it's possible to do it (ON, OFF, S-, M, S+, W).