### PR TITLE
Remove `origin` key from discovery payload, which is apparently wrong?

### DIFF
--- a/lib/MQTT/HomeAssistantDiscoveryClient.cpp
+++ b/lib/MQTT/HomeAssistantDiscoveryClient.cpp
@@ -59,9 +59,6 @@ void HomeAssistantDiscoveryClient::addConfig(const char* alias, const BulbId& bu
   config[F("stat_t")] = mqttClient->bindTopicString(settings.mqttStateTopicPattern, bulbId);
   config[F("uniq_id")] = uniqueIdBuffer;
 
-  JsonObject originMetadata = config.createNestedObject(F("o"));
-  originMetadata[F("url")] = deviceUrl;
-
   JsonObject deviceMetadata = config.createNestedObject(F("dev"));
   deviceMetadata[F("name")] = settings.hostname;
   deviceMetadata[F("sw")] = fwVersion;


### PR DESCRIPTION
Even after re-reading the docs, I think I was doing this correctly?

https://www.home-assistant.io/integrations/mqtt/

But was definitely getting the error mentioned in #804. Removing this fixes the issue and I don't think this guy was serving any function except that the docs encourage the origin information to be included.

So away it goes.