### PR TITLE
Add support to decode the FUT092 remote

### DIFF
--- a/lib/MiLight/FUT089PacketFormatter.cpp
+++ b/lib/MiLight/FUT089PacketFormatter.cpp
@@ -29,58 +29,14 @@ void FUT089PacketFormatter::updateColorRaw(uint8_t value) {
   command(FUT089_COLOR, FUT089_COLOR_OFFSET + value);
 }
 
-// change the temperature (kelvin).  Note that temperature and saturation share the same command
-// number (7), and they change which they do based on the mode of the lamp (white vs. color mode).
-// To make this command work, we need to switch to white mode, make the change, and then flip
-// back to the original mode.
+// change the temperature (kelvin). Update: now uses the fut092 command to skip mode changes
 void FUT089PacketFormatter::updateTemperature(uint8_t value) {
-  // look up our current mode
-  const GroupState* ourState = this->stateStore->get(this->deviceId, this->groupId, REMOTE_TYPE_FUT089);
-  BulbMode originalBulbMode;
-
-  if (ourState != NULL) {
-    originalBulbMode = ourState->getBulbMode();
-
-    // are we already in white?  If not, change to white
-    if (originalBulbMode != BulbMode::BULB_MODE_WHITE) {
-      updateColorWhite();
-    }
-  }
-
-  // now make the temperature change
-  command(FUT089_KELVIN_SATURATION, 100 - value);
-
-  // and return to our original mode
-  if (ourState != NULL && (settings->enableAutomaticModeSwitching) && (originalBulbMode != BulbMode::BULB_MODE_WHITE)) {
-    switchMode(*ourState, originalBulbMode);
-  }
+  command(FUT092_KELVIN, 100 - value);
 }
 
-// change the saturation.  Note that temperature and saturation share the same command
-// number (7), and they change which they do based on the mode of the lamp (white vs. color mode).
-// Therefore, if we are not in color mode, we need to switch to color mode, make the change,
-// and switch back to the original mode.
+// change the saturation. Update: now uses the fut092 command to skip mode changes
 void FUT089PacketFormatter::updateSaturation(uint8_t value) {
-  // look up our current mode
-  const GroupState* ourState = this->stateStore->get(this->deviceId, this->groupId, REMOTE_TYPE_FUT089);
-  BulbMode originalBulbMode = BulbMode::BULB_MODE_WHITE;
-
-  if (ourState != NULL) {
-    originalBulbMode = ourState->getBulbMode();
-  }
-
-  // are we already in color?  If not, we need to flip modes
-  if (ourState != NULL && (settings->enableAutomaticModeSwitching) && (originalBulbMode != BulbMode::BULB_MODE_COLOR)) {
-    updateHue(ourState->getHue());
-  }
-
-  // now make the saturation change
-  command(FUT089_KELVIN_SATURATION, 100 - value);
-
-  // and revert back if necessary
-  if (ourState != NULL && (settings->enableAutomaticModeSwitching) && (originalBulbMode != BulbMode::BULB_MODE_COLOR)) {
-    switchMode(*ourState, originalBulbMode);
-  }
+  command(FUT092_SATURATION, 100 - value);
 }
 
 void FUT089PacketFormatter::updateColorWhite() {

--- a/lib/MiLight/FUT089PacketFormatter.h
+++ b/lib/MiLight/FUT089PacketFormatter.h
@@ -9,10 +9,11 @@ enum MiLightFUT089Command {
   FUT089_ON = 0x01,
   FUT089_OFF = 0x01,
   FUT089_COLOR = 0x02,
+  FUT092_KELVIN = 0x03,           // The FUT092 uses the same protocol, but has separate temperature and saturation commands
+  FUT092_SATURATION = 0x04,       // Used by FUT092
   FUT089_BRIGHTNESS = 0x05,
   FUT089_MODE = 0x06,
-  FUT089_KELVIN = 0x07,     // Controls Kelvin when in White mode
-  FUT089_SATURATION = 0x07  // Controls Saturation when in Color mode
+  FUT089_KELVIN_SATURATION = 0x07 // Controls Kelvin when in White mode, controls Saturation when in Color mode
 };
 
 enum MiLightFUT089Arguments {


### PR DESCRIPTION
It uses the same protocol as FUT089, but has separate commands for color temperature and saturation.

Closes #844

Please review my naming changes (I used FUT092 in the same enum as FUT089 options, not sure if that is appropriate).

I chose not to change the `updateTemperature` and `updateSaturation` methods, because that would require testing on a RGB light. However, it should be possible to use the new commands to avoid the current mode-dependent behavior.