### PR TITLE
Update HomeAssistantDiscoveryClient.cpp

### DIFF
--- a/lib/MQTT/HomeAssistantDiscoveryClient.cpp
+++ b/lib/MQTT/HomeAssistantDiscoveryClient.cpp
@@ -81,6 +81,8 @@ void HomeAssistantDiscoveryClient::addConfig(const char* alias, const BulbId& bu
     config[F("pl_not_avail")] = F("disconnected");
   }
 
+  // To remain compatible with Homeassistant and Domoticz
+  config[GroupStateFieldNames::BRIGHTNESS] = true;
   // Configure supported commands based on the bulb type
   config[GroupStateFieldNames::EFFECT] = true;
 


### PR DESCRIPTION
Added: config[GroupStateFieldNames::BRIGHTNESS] = true; For compatibility with Domoticz 2024.x

https://github.com/sidoh/esp8266_milight_hub/pull/834