### PR TITLE
Adds B05 Milight remote as supported Device #860

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Model #|Name|Compatible Bulbs
 |FUT092|RGB/CCT|<ol><li>FUT012</li><li>FUT013</li><li>FUT014</li><li>FUT015</li><li>FUT103</li><li>FUT104</li><li>FUT105</li><li>Many RGB/CCT LED Strip Controllers</li></ol>|
 |FUT091|CCT v2|Most newer dual white bulbs and controllers|
 |FUT089|8-zone RGB/CCT|Most newer rgb + dual white bulbs and controllers|
+|B05|4-zone RGB/CCT|?|
 
 Other remotes or bulbs, but have not been tested.
 


### PR DESCRIPTION
As noted in #860 , I can testify that the B05 remote is supported.