### PR TITLE
New-board/WT-ETH01

### DIFF
--- a/lib/MQTT/HomeAssistantDiscoveryClient.cpp
+++ b/lib/MQTT/HomeAssistantDiscoveryClient.cpp
@@ -52,7 +52,11 @@ void HomeAssistantDiscoveryClient::addConfig(const char* alias, const BulbId& bu
 
   // URL to the device
   char deviceUrl[23];
+#ifdef IS_WT32_ETH01
+  snprintf_P(deviceUrl, sizeof(deviceUrl), PSTR("http://%s"), ETH.localIP().toString().c_str());
+#else
   snprintf_P(deviceUrl, sizeof(deviceUrl), PSTR("http://%s"), WiFi.localIP().toString().c_str());
+#endif
 
   config[F("dev_cla")] = F("light");
   config[F("schema")] = F("json");

--- a/lib/MQTT/HomeAssistantDiscoveryClient.h
+++ b/lib/MQTT/HomeAssistantDiscoveryClient.h
@@ -4,7 +4,9 @@
 #include <MqttClient.h>
 #include <ESPId.h>
 #include <map>
-
+#ifdef IS_WT32_ETH01
+  #include <ETH.h>
+#endif
 class HomeAssistantDiscoveryClient {
 public:
   HomeAssistantDiscoveryClient(Settings& settings, MqttClient* mqttClient);

--- a/lib/Radio/NRF24MiLightRadio.cpp
+++ b/lib/Radio/NRF24MiLightRadio.cpp
@@ -2,7 +2,7 @@
 
 #include <PL1167_nRF24.h>
 #include <NRF24MiLightRadio.h>
-
+ 
 #define PACKET_ID(packet, packet_length) ( (packet[1] << 8) | packet[packet_length - 1] )
 
 NRF24MiLightRadio::NRF24MiLightRadio(
@@ -19,6 +19,9 @@ NRF24MiLightRadio::NRF24MiLightRadio(
 { }
 
 int NRF24MiLightRadio::begin() {
+  #ifdef IS_WT32_ETH01
+    SPI.begin(NRF_SPI_SCK, NRF_SPI_MISO, NRF_SPI_MOSI);   // Remapping of SPI-Pins
+  #endif
   int retval = _pl1167.open();
   if (retval < 0) {
     return retval;

--- a/lib/Radio/NRF24MiLightRadio.cpp
+++ b/lib/Radio/NRF24MiLightRadio.cpp
@@ -19,9 +19,6 @@ NRF24MiLightRadio::NRF24MiLightRadio(
 { }
 
 int NRF24MiLightRadio::begin() {
-  #ifdef IS_WT32_ETH01
-    SPI.begin(NRF_SPI_SCK, NRF_SPI_MISO, NRF_SPI_MOSI);   // Remapping of SPI-Pins
-  #endif
   int retval = _pl1167.open();
   if (retval < 0) {
     return retval;

--- a/lib/Settings/AboutHelper.cpp
+++ b/lib/Settings/AboutHelper.cpp
@@ -36,7 +36,13 @@ String AboutHelper::generateAboutString(bool abbreviated) {
 void AboutHelper::generateAboutObject(JsonDocument &obj, bool abbreviated) {
   obj[FPSTR("firmware")] = QUOTE(FIRMWARE_NAME);
   obj[FPSTR("version")] = QUOTE(MILIGHT_HUB_VERSION);
+
+#ifdef IS_WT32_ETH01
+  obj[FPSTR("ip_address")] = ETH.localIP().toString();
+#else
   obj[FPSTR("ip_address")] = WiFi.localIP().toString();
+#endif
+
 #ifdef ESP8266
   obj[FPSTR("reset_reason")] = ESP.getResetReason();
 #elif ESP32

--- a/lib/Settings/AboutHelper.h
+++ b/lib/Settings/AboutHelper.h
@@ -1,6 +1,8 @@
 #include <Arduino.h>
 #include <ArduinoJson.h>
-
+#ifdef IS_WT32_ETH01
+  #include <ETH.h>
+#endif
 #ifndef _ABOUT_STRING_HELPER_H
 #define _ABOUT_STRING_HELPER_H
 

--- a/lib/Udp/MiLightDiscoveryServer.cpp
+++ b/lib/Udp/MiLightDiscoveryServer.cpp
@@ -65,7 +65,11 @@ void MiLightDiscoveryServer::handleDiscovery(uint8_t version) {
       continue;
     }
 
+  #ifdef IS_WT32_ETH01
+    IPAddress addr = ETH.localIP();
+  #else
     IPAddress addr = WiFi.localIP();
+  #endif
     char* ptr = buffer;
     ptr += sprintf_P(
       buffer,

--- a/lib/Udp/MiLightDiscoveryServer.h
+++ b/lib/Udp/MiLightDiscoveryServer.h
@@ -1,6 +1,8 @@
 #include <WiFiUdp.h>
 #include <Settings.h>
-
+#ifdef IS_WT32_ETH01
+  #include <ETH.h>
+#endif
 #ifndef MILIGHT_DISCOVERY_SERVER_H
 #define MILIGHT_DISCOVERY_SERVER_H
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -122,7 +122,7 @@ upload_command = curl.exe -F "image=@$SOURCE" http://$UPLOAD_PORT/firmware
 [env:wt32-eth01]
 extends = esp32
 board = wt32-eth01
-board_f_cpu = 240000000L
+board_build.f_cpu = 240000000L
 board_build.partitions = min_spiffs.csv
 upload_port = COM6   ;change on your own needs
 build_flags = 
@@ -134,12 +134,13 @@ build_flags =
   ; NRF24L01+ configuration with GPIO remapping
   -D NRF_SPI_BUS=HSPI
   -D NRF_SPI_MISO=35
-  -D NRF_SPI_MOSI=15
+  -D NRF_SPI_MOSI=12
   -D NRF_SPI_SCK=14
   -D IS_WT32_ETH01
-  ; Spezifische Pins für den LAN8720A Ethernet PHY Chip
-  ;  -D ETH_PHY_ADDR=1
-  ;  -D ETH_MDC_PIN=23
-  ;  -D ETH_MDIO_PIN=18
-  ;  -D ETH_POWER_PIN=21  ; Standard Pin für Power/Reset des LAN8720A
-  ;  -D ETH_CLK_MODE=ETH_CLOCK_GPIO0_IN ; Wichtig: WT32-ETH01 nutzt externen 50MHz Oszillator an GPIO0
+  ; Specify pins for the LAN8720A Ethernet PHY Chip
+  -D ETH_PHY_ADDR=1
+  -D ETH_MDC_PIN=23
+  -D ETH_MDIO_PIN=18
+  -D ETH_POWER_PIN=16
+  -D ETH_CLK_MODE=ETH_CLOCK_GPIO0_IN
+  -D ETH_PHY_TYPE=ETH_PHY_LAN8720

--- a/platformio.ini
+++ b/platformio.ini
@@ -17,6 +17,7 @@ default_envs =
   huzzah
   d1_mini_pro
   esp32
+  wt32-eth01
 
 [base]
 framework = arduino
@@ -117,3 +118,28 @@ extends = env:debug
 upload_port = 10.133.8.221
 upload_protocol = custom
 upload_command = curl.exe -F "image=@$SOURCE" http://$UPLOAD_PORT/firmware
+
+[env:wt32-eth01]
+extends = esp32
+board = wt32-eth01
+board_f_cpu = 240000000L
+board_build.partitions = min_spiffs.csv
+upload_port = COM6   ;change on your own needs
+build_flags = 
+  ${esp32.build_flags}
+  -D FIRMWARE_VARIANT=esp32_ethernet
+  -D MI_CE_PIN=32         ;must be put into settings in web-ui too
+  -D MI_CSN_PIN=4         ;must be put into settings in web-ui too
+  -D MI_RESET_PIN=33      ;must be put into settings in web-ui too
+  ; NRF24L01+ configuration with GPIO remapping
+  -D NRF_SPI_BUS=HSPI
+  -D NRF_SPI_MISO=35
+  -D NRF_SPI_MOSI=15
+  -D NRF_SPI_SCK=14
+  -D IS_WT32_ETH01
+  ; Spezifische Pins für den LAN8720A Ethernet PHY Chip
+  ;  -D ETH_PHY_ADDR=1
+  ;  -D ETH_MDC_PIN=23
+  ;  -D ETH_MDIO_PIN=18
+  ;  -D ETH_POWER_PIN=21  ; Standard Pin für Power/Reset des LAN8720A
+  ;  -D ETH_CLK_MODE=ETH_CLOCK_GPIO0_IN ; Wichtig: WT32-ETH01 nutzt externen 50MHz Oszillator an GPIO0

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -335,13 +335,16 @@ bool shouldRestart() {
 }
 
 void wifiExtraSettingsChange() {
+  if (wifiStaticIP == NULL || wifiStaticIPNetmask == NULL) {
+    return;
+  }
+
   settings.wifiStaticIP = wifiStaticIP->getValue();
   settings.wifiStaticIPNetmask = wifiStaticIPNetmask->getValue();
   settings.wifiStaticIPGateway = wifiStaticIPGateway->getValue();
   settings.wifiMode = Settings::wifiModeFromString(wifiMode->getValue());
   settings.save();
 
-  // Restart the device
   delay(1000);
   ESP.restart();
 }
@@ -460,23 +463,39 @@ void setup() {
     wifiManager = nullptr; 
     
     Serial.println(F("Ethernet Setup abgeschlossen."));
+#else
+  // --- Standard WiFi Pfad ---
+  ESPMH_SETUP_WIFI(settings);
+  applySettings();
 
-  #else
-    ESPMH_SETUP_WIFI(settings);
-    applySettings();
+  ledStatus = new LEDStatus(settings.ledPin);
+  ledStatus->continuous(settings.ledModeWifiConfig);
 
-    ledStatus = new LEDStatus(settings.ledPin);
-    ledStatus->continuous(settings.ledModeWifiConfig);
+  if (! MDNS.begin("milight-hub")) { Serial.println(F("Error setting up MDNS responder")); }
 
-    if (! MDNS.begin("milight-hub")) { Serial.println(F("Error setting up MDNS responder")); }
+  wifiManager = new WiFiManager();
+  
+  // Diese Zeilen sind wichtig für die Stabilität des WiFi-Portals:
+  wifiManager->setBreakAfterConfig(true);
+  wifiManager->setSaveConfigCallback(wifiExtraSettingsChange);
+  wifiManager->setConfigPortalBlocking(false);
 
-    wifiManager = new WiFiManager();
-    
-    if (wifiManager->autoConnect(ssid.c_str(), "milightHub")) {
-       WiFi.mode(WIFI_STA);
-       postConnectSetup();
-    }
-  #endif
+  // Parameter initialisieren
+  wifiStaticIP = new WiFiManagerParameter("staticIP", "Static IP", settings.wifiStaticIP.c_str(), MAX_IP_ADDR_LEN);
+  wifiStaticIPNetmask = new WiFiManagerParameter("netmask", "Netmask", settings.wifiStaticIPNetmask.c_str(), MAX_IP_ADDR_LEN);
+  wifiStaticIPGateway = new WiFiManagerParameter("gateway", "Gateway", settings.wifiStaticIPGateway.c_str(), MAX_IP_ADDR_LEN);
+  wifiMode = new WiFiManagerParameter("wifiMode", "WiFi Mode (b/g/n)", settings.wifiMode == WifiMode::B ? "b" : "g", 1);
+
+  wifiManager->addParameter(wifiStaticIP);
+  wifiManager->addParameter(wifiStaticIPNetmask);
+  wifiManager->addParameter(wifiStaticIPGateway);
+  wifiManager->addParameter(wifiMode);
+
+  if (wifiManager->autoConnect(ssid.c_str(), "milightHub")) {
+      WiFi.mode(WIFI_STA);
+      postConnectSetup();
+  }
+#endif
 }
 size_t i = 0;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -309,10 +309,10 @@ void applySettings() {
   }
 
   // --- Netzwerk-config differentiation ---
-#ifdef IS_WT32_ETH01
-  ETH.setHostname(settings.hostname.c_str());
-  Serial.printf_P(PSTR("Ethernet Hostname set to: %s\n"), settings.hostname.c_str());
-#else
+  #ifdef IS_WT32_ETH01
+    ETH.setHostname(settings.hostname.c_str());
+    Serial.printf_P(PSTR("Ethernet Hostname set to: %s\n"), settings.hostname.c_str());
+  #else
   WiFi.hostname(settings.hostname);
   #ifdef ESP8266
     WiFiPhyMode_t wifiPhyMode;
@@ -347,7 +347,10 @@ bool shouldRestart() {
 }
 
 void wifiExtraSettingsChange() {
-  if (wifiStaticIP == NULL || wifiStaticIPNetmask == NULL) {
+  if (wifiManager == nullptr || wifiStaticIP == nullptr || 
+      wifiStaticIPNetmask == nullptr || wifiStaticIPGateway == nullptr || 
+      wifiMode == nullptr) {
+    Serial.println(F("WiFi settings change ignored (Ethernet mode or unitialized)"));
     return;
   }
 
@@ -355,6 +358,8 @@ void wifiExtraSettingsChange() {
   settings.wifiStaticIPNetmask = wifiStaticIPNetmask->getValue();
   settings.wifiStaticIPGateway = wifiStaticIPGateway->getValue();
   settings.wifiMode = Settings::wifiModeFromString(wifiMode->getValue());
+  
+  Serial.println(F("Saving WiFi settings..."));
   settings.save();
 
   delay(1000);
@@ -487,17 +492,22 @@ void setup() {
 
   wifiManager = new WiFiManager();
   
-  // Diese Zeilen sind wichtig für die Stabilität des WiFi-Portals:
   wifiManager->setBreakAfterConfig(true);
   wifiManager->setSaveConfigCallback(wifiExtraSettingsChange);
   wifiManager->setConfigPortalBlocking(false);
 
-  // Parameter initialisieren
   wifiStaticIP = new WiFiManagerParameter("staticIP", "Static IP", settings.wifiStaticIP.c_str(), MAX_IP_ADDR_LEN);
   wifiStaticIPNetmask = new WiFiManagerParameter("netmask", "Netmask", settings.wifiStaticIPNetmask.c_str(), MAX_IP_ADDR_LEN);
   wifiStaticIPGateway = new WiFiManagerParameter("gateway", "Gateway", settings.wifiStaticIPGateway.c_str(), MAX_IP_ADDR_LEN);
-  wifiMode = new WiFiManagerParameter("wifiMode", "WiFi Mode (b/g/n)", settings.wifiMode == WifiMode::B ? "b" : "g", 1);
 
+  const char* modeStr = "n";
+  if (settings.wifiMode == WifiMode::B) {
+    modeStr = "b";
+  } else if (settings.wifiMode == WifiMode::G) {
+    modeStr = "g";
+  }
+
+  wifiMode = new WiFiManagerParameter("wifiMode", "WiFi Mode (b/g/n)", modeStr, 1);
   wifiManager->addParameter(wifiStaticIP);
   wifiManager->addParameter(wifiStaticIPNetmask);
   wifiManager->addParameter(wifiStaticIPGateway);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -413,7 +413,7 @@ void postConnectSetup() {
   #ifdef IS_WT32_ETH01
     SSDP.setName("WT32 MiLight Ethernet Gateway");
   #else
-    SSDP.setName("ESP32 MiLight Gateway");
+    SSDP.setName("ESP8266 MiLight Gateway");
   #endif
   SSDP.setSerialNumber(getESPId());
   SSDP.setURL("/");
@@ -462,65 +462,76 @@ void setup() {
   #ifdef IS_WT32_ETH01
     Serial.println(F("WT32-ETH01: Powering on Ethernet PHY..."));
     pinMode(ETH_POWER_PIN, OUTPUT);
-    digitalWrite(ETH_POWER_PIN, HIGH); // PHY Power on
+    digitalWrite(ETH_POWER_PIN, HIGH); 
     delay(100);
-    Serial.println(F("WT32-ETH01 erkannt. Starte Ethernet..."));
-    // PHY_ADDR: 1, PHY_POWER: 16, MDC: 23, MDIO: 18, Type: LAN8720, Clock: GPIO0_IN
+    
     ETH.begin(1, ETH_POWER_PIN, ETH_MDC_PIN, ETH_MDIO_PIN, ETH_PHY_LAN8720, ETH_CLOCK_GPIO0_IN);
     delay(1000);
+    
     applySettings();
     
     ledStatus = new LEDStatus(settings.ledPin);
     ledStatus->continuous(settings.ledModeOperating);
 
     if (!MDNS.begin("milight-hub")) { Serial.println(F("Error MDNS")); }
-
+    
     postConnectSetup();
-    
     wifiManager = nullptr; 
-    
     Serial.println(F("Ethernet Setup abgeschlossen."));
-#else
-  // --- Standard WiFi Pfad ---
-  ESPMH_SETUP_WIFI(settings);
-  applySettings();
 
-  ledStatus = new LEDStatus(settings.ledPin);
-  ledStatus->continuous(settings.ledModeWifiConfig);
+  #else
+    ESPMH_SETUP_WIFI(settings);
+    applySettings();
 
-  if (! MDNS.begin("milight-hub")) { Serial.println(F("Error setting up MDNS responder")); }
+    ledStatus = new LEDStatus(settings.ledPin);
+    ledStatus->continuous(settings.ledModeWifiConfig);
 
-  wifiManager = new WiFiManager();
-  
-  wifiManager->setBreakAfterConfig(true);
-  wifiManager->setSaveConfigCallback(wifiExtraSettingsChange);
-  wifiManager->setConfigPortalBlocking(false);
+    if (! MDNS.begin("milight-hub")) { Serial.println(F("Error setting up MDNS responder")); }
 
-  wifiStaticIP = new WiFiManagerParameter("staticIP", "Static IP", settings.wifiStaticIP.c_str(), MAX_IP_ADDR_LEN);
-  wifiStaticIPNetmask = new WiFiManagerParameter("netmask", "Netmask", settings.wifiStaticIPNetmask.c_str(), MAX_IP_ADDR_LEN);
-  wifiStaticIPGateway = new WiFiManagerParameter("gateway", "Gateway", settings.wifiStaticIPGateway.c_str(), MAX_IP_ADDR_LEN);
+    wifiManager = new WiFiManager();
+    wifiManager->setBreakAfterConfig(true);
+    wifiManager->setSaveConfigCallback(wifiExtraSettingsChange);
+    wifiManager->setConfigPortalBlocking(false);
+    wifiManager->setConnectTimeout(20);
+    wifiManager->setConnectRetries(5);
 
-  const char* modeStr = "n";
-  if (settings.wifiMode == WifiMode::B) {
-    modeStr = "b";
-  } else if (settings.wifiMode == WifiMode::G) {
-    modeStr = "g";
-  }
+    // Parameter Definitionen
+    wifiStaticIP = new WiFiManagerParameter("staticIP", "Static IP (Leave blank for dhcp)", settings.wifiStaticIP.c_str(), MAX_IP_ADDR_LEN);
+    wifiStaticIPNetmask = new WiFiManagerParameter("netmask", "Netmask (required if IP given)", settings.wifiStaticIPNetmask.c_str(), MAX_IP_ADDR_LEN);
+    wifiStaticIPGateway = new WiFiManagerParameter("gateway", "Default Gateway (optional)", settings.wifiStaticIPGateway.c_str(), MAX_IP_ADDR_LEN);
 
-  wifiMode = new WiFiManagerParameter("wifiMode", "WiFi Mode (b/g/n)", modeStr, 1);
-  wifiManager->addParameter(wifiStaticIP);
-  wifiManager->addParameter(wifiStaticIPNetmask);
-  wifiManager->addParameter(wifiStaticIPGateway);
-  wifiManager->addParameter(wifiMode);
+    const char* modeStr = (settings.wifiMode == WifiMode::B) ? "b" : (settings.wifiMode == WifiMode::G) ? "g" : "n";
+    wifiMode = new WiFiManagerParameter("wifiMode", "WiFi Mode (b/g/n)", modeStr, 1);
 
-  if (wifiManager->autoConnect(ssid.c_str(), "milightHub")) {
-      WiFi.mode(WIFI_STA);
-      postConnectSetup();
-  }
-#endif
+    wifiManager->addParameter(wifiStaticIP);
+    wifiManager->addParameter(wifiStaticIPNetmask);
+    wifiManager->addParameter(wifiStaticIPGateway);
+    wifiManager->addParameter(wifiMode);
+
+    if (settings.wifiStaticIP.length() > 0) {
+      IPAddress _ip, _subnet, _gw;
+      if (_ip.fromString(settings.wifiStaticIP)) {
+        _subnet.fromString(settings.wifiStaticIPNetmask);
+        _gw.fromString(settings.wifiStaticIPGateway);
+        wifiManager->setSTAStaticIPConfig(_ip, _gw, _subnet);
+      }
+    }
+
+    wifiManager->setConfigPortalTimeout(180);
+    wifiManager->setConfigPortalTimeoutCallback([]() {
+        ledStatus->continuous(settings.ledModeWifiFailed);
+        Serial.println(F("Wifi config portal timed out. Restarting..."));
+        delay(10000);
+        ESP.restart();
+    });
+
+    if (wifiManager->autoConnect(ssid.c_str(), "milightHub")) {
+        ledStatus->continuous(settings.ledModeOperating);
+        WiFi.mode(WIFI_STA);
+        postConnectSetup();
+    }
+  #endif
 }
-size_t i = 0;
-
 
 void loop() {
   ledStatus->handle();
@@ -530,23 +541,21 @@ void loop() {
     ESP.restart();
   }
 
-  // WiFiManager nur verarbeiten, wenn er existiert
   if (wifiManager) {
     wifiManager->process();
   }
 
-  // Netzwerk-Check: Entweder WiFi ODER Ethernet
   bool connected = false;
   #ifdef IS_WT32_ETH01
-    connected = (ETH.localIP()[0] != 0); // Wahr, wenn wir eine IP haben
+    connected = (ETH.localIP()[0] != 0);
   #else
     connected = (WiFi.getMode() == WIFI_STA && WiFi.isConnected());
   #endif
 
   if (connected) {
     postConnectSetup();
-
     httpServer->handleClient();
+    
     if (mqttClient) {
       mqttClient->handleClient();
       bulbStateUpdater->loop();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -70,11 +70,7 @@ TransitionController transitions;
 
 std::vector<std::shared_ptr<MiLightUdpServer>> udpServers;
 
-/**
- * Set up UDP servers (both v5 and v6).  Clean up old ones if necessary.
- */
-
- /**
+ /*
  * Set up UDP servers (both v5 and v6). Clean up old ones if necessary.
  */
 void initMilightUdpServers() {
@@ -476,7 +472,7 @@ void setup() {
     
     postConnectSetup();
     wifiManager = nullptr; 
-    Serial.println(F("Ethernet Setup abgeschlossen."));
+    Serial.println(F("Ethernet Setup done"));
 
   #else
     ESPMH_SETUP_WIFI(settings);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,6 +39,10 @@
 #include <memory>
 #include "ProjectFS.h"
 
+#ifdef IS_WT32_ETH01
+  #include <ETH.h>
+#endif
+
 WiFiManager* wifiManager;
 // because of callbacks, these need to be in the higher scope :(
 WiFiManagerParameter* wifiStaticIP = NULL;
@@ -241,6 +245,12 @@ void applySettings() {
 
   transitions.setDefaultPeriod(settings.defaultTransitionPeriod);
 
+  // --- WT32-ETH01 SPI Remapping ---
+  #ifdef IS_WT32_ETH01
+    Serial.println(F("WT32-ETH01: Re-initializing SPI pins..."));
+    SPI.begin(NRF_SPI_SCK, NRF_SPI_MISO, NRF_SPI_MOSI, settings.csnPin);
+  #endif
+
   radioFactory = MiLightRadioFactory::fromSettings(settings);
 
   if (radioFactory == NULL) {
@@ -286,39 +296,33 @@ void applySettings() {
     ledStatus->continuous(settings.ledModeOperating);
   }
 
+  // --- Netzwerk-config differentiation ---
+#ifdef IS_WT32_ETH01
+  ETH.setHostname(settings.hostname.c_str());
+  Serial.printf_P(PSTR("Ethernet Hostname set to: %s\n"), settings.hostname.c_str());
+#else
   WiFi.hostname(settings.hostname);
-#ifdef ESP8266
-  WiFiPhyMode_t wifiPhyMode;
-switch (settings.wifiMode) {
-  case WifiMode::B:
-    wifiPhyMode = WIFI_PHY_MODE_11B;
-    break;
-  case WifiMode::G:
-    wifiPhyMode = WIFI_PHY_MODE_11G;
-    break;
-  default:
-  case WifiMode::N:
-    wifiPhyMode = WIFI_PHY_MODE_11N;
-    break;
-}
-  WiFi.setPhyMode(wifiPhyMode);
-#elif ESP32
-  switch (settings.wifiMode) {
-    case WifiMode::B:
-      esp_wifi_set_protocol(WIFI_IF_STA, WIFI_PROTOCOL_11B);
-      break;
-    case WifiMode::G:
-      esp_wifi_set_protocol(WIFI_IF_STA, WIFI_PROTOCOL_11G);
-      break;
-    default:
-    case WifiMode::N:
-      esp_wifi_set_protocol(WIFI_IF_STA, WIFI_PROTOCOL_11N);
-      break;
-  }
-  esp_wifi_set_bandwidth(WIFI_IF_STA, WIFI_BW_HT20);
+  #ifdef ESP8266
+    WiFiPhyMode_t wifiPhyMode;
+    switch (settings.wifiMode) {
+      case WifiMode::B: wifiPhyMode = WIFI_PHY_MODE_11B; break;
+      case WifiMode::G: wifiPhyMode = WIFI_PHY_MODE_11G; break;
+      default:
+      case WifiMode::N: wifiPhyMode = WIFI_PHY_MODE_11N; break;
+    }
+    WiFi.setPhyMode(wifiPhyMode);
+  #elif ESP32
+    switch (settings.wifiMode) {
+      case WifiMode::B: esp_wifi_set_protocol(WIFI_IF_STA, WIFI_PROTOCOL_11B); break;
+      case WifiMode::G: esp_wifi_set_protocol(WIFI_IF_STA, WIFI_PROTOCOL_11G); break;
+      default:
+      case WifiMode::N: esp_wifi_set_protocol(WIFI_IF_STA, WIFI_PROTOCOL_11N); break;
+    }
+    esp_wifi_set_bandwidth(WIFI_IF_STA, WIFI_BW_HT20);
+  #endif
 #endif
 }
-
+ 
 /**
  *
  */
@@ -366,18 +370,31 @@ void onGroupDeleted(const BulbId& id) {
 }
 
 bool initialized = false;
+
 void postConnectSetup() {
   if (initialized) return;
+  
+  #ifdef IS_WT32_ETH01
+    if (ETH.localIP()[0] == 0) return; 
+  #endif
+
   initialized = true;
 
-  delete wifiManager;
-  wifiManager = NULL;
+  // only delete if exists
+  if (wifiManager != NULL) {
+    delete wifiManager;
+    wifiManager = NULL;
+  }
 
   MDNS.addService("http", "tcp", 80);
 
   SSDP.setSchemaURL("description.xml");
   SSDP.setHTTPPort(80);
-  SSDP.setName("ESP8266 MiLight Gateway");
+  #ifdef IS_WT32_ETH01
+    SSDP.setName("WT32 MiLight Ethernet Gateway");
+  #else
+    SSDP.setName("ESP32 MiLight Gateway");
+  #endif
   SSDP.setSerialNumber(getESPId());
   SSDP.setURL("/");
   SSDP.setDeviceType("upnp:rootdevice");
@@ -393,7 +410,6 @@ void postConnectSetup() {
   transitions.addListener(
       [](const BulbId& bulbId, GroupStateField field, uint16_t value) {
           StaticJsonDocument<100> buffer;
-
           const char* fieldName = GroupStateFieldHelpers::getFieldName(field);
           buffer[fieldName] = value;
 
@@ -405,118 +421,67 @@ void postConnectSetup() {
   initMilightUdpServers();
 
   Serial.printf_P(PSTR("Setup complete (version %s)\n"), QUOTE(MILIGHT_HUB_VERSION));
+  #ifdef IS_WT32_ETH01
+    Serial.print(F("Ethernet IP: "));
+    Serial.println(ETH.localIP());
+  #endif
 }
 
 void setup() {
   Serial.begin(9600);
   String ssid = "ESP" + String(getESPId());
 
-  // load up our persistent settings from the file system
-  // ESP8266 doesn't support the formatOnFail parameter
   #ifdef ESP8266
-    if (! ProjectFS.begin()) {
-      Serial.println(F("Failed to mount file system"));
-    }
+    if (! ProjectFS.begin()) { Serial.println(F("Failed to mount file system")); }
   #else
-    if (! ProjectFS.begin(true)) {
-      Serial.println(F("Failed to mount file system"));
-    }
+    if (! ProjectFS.begin(true)) { Serial.println(F("Failed to mount file system")); }
   #endif
 
   Settings::load(settings);
-  ESPMH_SETUP_WIFI(settings);
-  applySettings();
 
-  // set up the LED status for wifi configuration
-  ledStatus = new LEDStatus(settings.ledPin);
-  ledStatus->continuous(settings.ledModeWifiConfig);
-
-  // start up the wifi manager
-  if (! MDNS.begin("milight-hub")) {
-    Serial.println(F("Error setting up MDNS responder"));
-  }
-
-  // Allows us to have static IP config in the captive portal. Yucky pointers to pointers, just to have the settings carry through
-  wifiManager = new WiFiManager();
-
-  // Setting breakAfterConfig to true causes wifiExtraSettingsChange to be called whenever config params are changed
-  // (even when connection fails or user is just changing settings and not network)
-  wifiManager->setBreakAfterConfig(true);
-  wifiManager->setSaveConfigCallback(wifiExtraSettingsChange);
-
-  wifiManager->setConfigPortalBlocking(false);
-  wifiManager->setConnectTimeout(20);
-  wifiManager->setConnectRetries(5);
-
-  wifiStaticIP = new WiFiManagerParameter(
-    "staticIP",
-    "Static IP (Leave blank for dhcp)",
-    settings.wifiStaticIP.c_str(),
-    MAX_IP_ADDR_LEN
-  );
-  wifiManager->addParameter(wifiStaticIP);
-
-  wifiStaticIPNetmask = new WiFiManagerParameter(
-    "netmask",
-    "Netmask (required if IP given)",
-    settings.wifiStaticIPNetmask.c_str(),
-    MAX_IP_ADDR_LEN
-  );
-  wifiManager->addParameter(wifiStaticIPNetmask);
-
-  wifiStaticIPGateway = new WiFiManagerParameter(
-    "gateway",
-    "Default Gateway (optional, only used if static IP)",
-    settings.wifiStaticIPGateway.c_str(),
-    MAX_IP_ADDR_LEN
-  );
-  wifiManager->addParameter(wifiStaticIPGateway);
-
-  wifiMode = new WiFiManagerParameter(
-    "wifiMode",
-    "WiFi Mode (b/g/n)",
-    settings.wifiMode == WifiMode::B ? "b" : settings.wifiMode == WifiMode::G ? "g" : "n",
-    1
-  );
-  wifiManager->addParameter(wifiMode);
-
-  // We have a saved static IP, let's try and use it.
-  if (settings.wifiStaticIP.length() > 0) {
-    Serial.printf_P(PSTR("We have a static IP: %s\n"), settings.wifiStaticIP.c_str());
-
-    IPAddress _ip, _subnet, _gw;
-    _ip.fromString(settings.wifiStaticIP);
-    _subnet.fromString(settings.wifiStaticIPNetmask);
-    _gw.fromString(settings.wifiStaticIPGateway);
-
-    wifiManager->setSTAStaticIPConfig(_ip,_gw,_subnet);
-  }
-
-  wifiManager->setConfigPortalTimeout(180);
-  wifiManager->setConfigPortalTimeoutCallback([]() {
-      ledStatus->continuous(settings.ledModeWifiFailed);
-
-      Serial.println(F("Wifi config portal timed out.  Restarting..."));
-      delay(10000);
-      ESP.restart();
-  });
-
-  if (wifiManager->autoConnect(ssid.c_str(), "milightHub")) {
-    // set LED mode for successful operation
+  #ifdef IS_WT32_ETH01
+    Serial.println(F("WT32-ETH01: Powering on Ethernet PHY..."));
+    pinMode(ETH_POWER_PIN, OUTPUT);
+    digitalWrite(ETH_POWER_PIN, HIGH); // PHY Power on
+    delay(100);
+    Serial.println(F("WT32-ETH01 erkannt. Starte Ethernet..."));
+    // PHY_ADDR: 1, PHY_POWER: 16, MDC: 23, MDIO: 18, Type: LAN8720, Clock: GPIO0_IN
+    ETH.begin(1, ETH_POWER_PIN, ETH_MDC_PIN, ETH_MDIO_PIN, ETH_PHY_LAN8720, ETH_CLOCK_GPIO0_IN);
+    delay(1000);
+    applySettings();
+    
+    ledStatus = new LEDStatus(settings.ledPin);
     ledStatus->continuous(settings.ledModeOperating);
-    Serial.println(F("Wifi connected succesfully\n"));
 
-    // if the config portal was started, make sure to turn off the config AP
-    WiFi.mode(WIFI_STA);
+    if (!MDNS.begin("milight-hub")) { Serial.println(F("Error MDNS")); }
 
     postConnectSetup();
-  }
-}
+    
+    wifiManager = nullptr; 
+    
+    Serial.println(F("Ethernet Setup abgeschlossen."));
 
+  #else
+    ESPMH_SETUP_WIFI(settings);
+    applySettings();
+
+    ledStatus = new LEDStatus(settings.ledPin);
+    ledStatus->continuous(settings.ledModeWifiConfig);
+
+    if (! MDNS.begin("milight-hub")) { Serial.println(F("Error setting up MDNS responder")); }
+
+    wifiManager = new WiFiManager();
+    
+    if (wifiManager->autoConnect(ssid.c_str(), "milightHub")) {
+       WiFi.mode(WIFI_STA);
+       postConnectSetup();
+    }
+  #endif
+}
 size_t i = 0;
 
+
 void loop() {
-  // update LED with status
   ledStatus->handle();
 
   if (shouldRestart()) {
@@ -524,11 +489,20 @@ void loop() {
     ESP.restart();
   }
 
+  // WiFiManager nur verarbeiten, wenn er existiert
   if (wifiManager) {
     wifiManager->process();
   }
 
-  if (WiFi.getMode() == WIFI_STA && WiFi.isConnected()) {
+  // Netzwerk-Check: Entweder WiFi ODER Ethernet
+  bool connected = false;
+  #ifdef IS_WT32_ETH01
+    connected = (ETH.localIP()[0] != 0); // Wahr, wenn wir eine IP haben
+  #else
+    connected = (WiFi.getMode() == WIFI_STA && WiFi.isConnected());
+  #endif
+
+  if (connected) {
     postConnectSetup();
 
     httpServer->handleClient();
@@ -546,10 +520,8 @@ void loop() {
     }
 
     handleListen();
-
     stateStore->limitedFlush();
     packetSender->loop();
-
     transitions.loop();
   }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -73,8 +73,20 @@ std::vector<std::shared_ptr<MiLightUdpServer>> udpServers;
 /**
  * Set up UDP servers (both v5 and v6).  Clean up old ones if necessary.
  */
+
+ /**
+ * Set up UDP servers (both v5 and v6). Clean up old ones if necessary.
+ */
 void initMilightUdpServers() {
-  if (! WiFi.isConnected()) {
+  bool isConnected = false;
+  #ifdef IS_WT32_ETH01
+    isConnected = (ETH.localIP()[0] != 0); 
+  #else
+    isConnected = WiFi.isConnected();
+  #endif
+
+  if (!isConnected) {
+    Serial.println(F("UDP Servers: No network connection. Skipping init."));
     return;
   }
 
@@ -95,7 +107,7 @@ void initMilightUdpServers() {
       Serial.println(config.protocolVersion);
     } else {
       udpServers.push_back(std::move(server));
-      udpServers[i]->begin();
+      udpServers.back()->begin(); 
     }
   }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -259,10 +259,9 @@ void applySettings() {
 
   // --- WT32-ETH01 SPI Remapping ---
   #ifdef IS_WT32_ETH01
-    Serial.println(F("WT32-ETH01: Re-initializing SPI pins..."));
-    SPI.begin(NRF_SPI_SCK, NRF_SPI_MISO, NRF_SPI_MOSI, settings.csnPin);
+    Serial.println(F("WT32-ETH01: Initializing SPI Bus (HSPI)..."));
+    SPI.begin(NRF_SPI_SCK, NRF_SPI_MISO, NRF_SPI_MOSI); 
   #endif
-
   radioFactory = MiLightRadioFactory::fromSettings(settings);
 
   if (radioFactory == NULL) {
@@ -465,7 +464,7 @@ void setup() {
     digitalWrite(ETH_POWER_PIN, HIGH); 
     delay(100);
     
-    ETH.begin(1, ETH_POWER_PIN, ETH_MDC_PIN, ETH_MDIO_PIN, ETH_PHY_LAN8720, ETH_CLOCK_GPIO0_IN);
+    ETH.begin(ETH_PHY_ADDR, ETH_POWER_PIN, ETH_MDC_PIN, ETH_MDIO_PIN, ETH_PHY_LAN8720, ETH_CLOCK_GPIO0_IN);
     delay(1000);
     
     applySettings();


### PR DESCRIPTION
add WT32-ETH01 board with Ethernet connection
and NRF24L01 GPIO remapping

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces native Ethernet support for the WT32-ETH01 board and routes networking logic through `ETH` when `IS_WT32_ETH01` is defined.
> 
> - New `env:wt32-eth01` in `platformio.ini` with PHY config, `IS_WT32_ETH01`, and NRF24 HSPI pin remapping; sets `FIRMWARE_VARIANT=esp32_ethernet`
> - `src/main.cpp`: Ethernet init/power-up, hostname via `ETH.setHostname`, SPI `HSPI` init for NRF24, skip WiFiManager in Ethernet mode, connection checks and services (HTTP, SSDP, UDP, MQTT) gated to `ETH` when enabled
> - `HomeAssistantDiscoveryClient`, `AboutHelper`, and `MiLightDiscoveryServer`: use `ETH.localIP()` instead of `WiFi.localIP()` under `IS_WT32_ETH01`; headers updated to include `<ETH.h>`
> - Minor naming/UX tweaks (SSDP device name for Ethernet) and small cleanups (UDP server init indexing, comments/formatting)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a6798169dc25dc18c453b3d82dd1e0b65c838d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->